### PR TITLE
In #require command (via function load_deeply) check that no package defines "error" variable

### DIFF
--- a/src/findlib/topfind.ml.in
+++ b/src/findlib/topfind.ml.in
@@ -166,6 +166,10 @@ let load_deeply pkglist =
   (* Get the sorted list of ancestors *)
   let eff_pkglist =
     Findlib.package_deep_ancestors !predicates pkglist in
+  List.iter (fun pkg ->
+    try let error = Findlib.package_property !predicates pkg "error" in
+      failwith ("Error from package `" ^ pkg ^ "': " ^ error)
+    with Not_found -> ()) eff_pkglist ;
   (* Load the packages in turn: *)
   load eff_pkglist
 ;;


### PR DESCRIPTION
In #require command (via function load_deeply) check that no package
we're going to load defines the "error" variable, and if so, print out
the first one we encounter.  This can be used to check for conflicts
between packages.