### PR TITLE
Use let () around toplevel expression

### DIFF
--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -1224,12 +1224,12 @@ let ocamlc which () =
         (fun pkg ->
            Printf.fprintf
              initl
-             "Findlib.record_package Findlib.Record_core %S;;\n"
+             "let () = Findlib.record_package Findlib.Record_core %S;;\n"
              pkg
         )
         eff_packages;
       output_string initl
-	("Findlib.record_package_predicates [" ^
+	("let () = Findlib.record_package_predicates [" ^
 	 String.concat ";"
 	   (List.map
 	      (fun pred -> "\"" ^ String.escaped pred ^ "\"")


### PR DESCRIPTION
This is simply to ease use of findlib with code that may (transitively) bring in
ppx_js_style, which requires explicit type annotation of ignored values:

https://github.com/janestreet/ppx_js_style#-allow-unannotated-ignores

Without this fix, errors such as the following occur with `ocamlfind ocamlopt
-linkpkg -package ppx_jane ...`:

```
File "/tmp/findlib_initl319a54.ml", line 1, characters 0-49:
1 | Findlib.record_package Findlib.Record_core "unix";;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Jane Street style: Toplevel expression are not allowed here.
```