### PR TITLE
Provide for linking the native toplevel now exposed as 'ocamltoplevel.cmxa'

### DIFF
--- a/site-lib-src/compiler-libs/META.in
+++ b/site-lib-src/compiler-libs/META.in
@@ -30,10 +30,17 @@
 `)'
 
 `package "toplevel" ('
-`  requires = "compiler-libs.bytecomp compiler-libs.optcomp dynlink"'
+`  requires = "compiler-libs.bytecomp"'
 `  version = "[distributed with Ocaml]"'
 `  description = "Toplevel interactions"'
 `  archive(byte) = "ocamltoplevel.cma"'
+`)'
+
+`package "native-toplevel" ('
+`  requires = "compiler-libs.optcomp dynlink"'
+`  version = "[distributed with Ocaml]"'
+`  description = "Toplevel interactions"'
 `  archive(native) = "ocamltoplevel.cmxa"'
+`  exists_if = "ocamltoplevel.cmxa"'
 `)'
 

--- a/site-lib-src/compiler-libs/META.in
+++ b/site-lib-src/compiler-libs/META.in
@@ -30,7 +30,7 @@
 `)'
 
 `package "toplevel" ('
-`  requires = "compiler-libs.bytecomp"'
+`  requires = "compiler-libs.bytecomp compiler-libs.optcomp dynlink"'
 `  version = "[distributed with Ocaml]"'
 `  description = "Toplevel interactions"'
 `  archive(byte) = "ocamltoplevel.cma"'

--- a/src/findlib/META.in
+++ b/src/findlib/META.in
@@ -32,4 +32,5 @@ package "top" (
   description = "Package manager toplevel support"
   requires = "findlib.internal"
   archive(byte) = "findlib_top.cma"
+  archive(native) = "findlib_top.cmxa"
 )


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/pull/10124

This is clearly not optimal, since it will force linking to the native
backend and dynlink even for bytecode mode ; is there a way to specify
`requires(byte)` and `requires(native)` ?