### PR TITLE
Update opam file to 2.0 (for pinning) and remove dependency on str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/findlib/ocamlfind
 src/findlib/topfind
 src/findlib/topfind.ml
 tools/extract_args/extract_args
+tools/extract_args/extract_args.ml

--- a/configure
+++ b/configure
@@ -7,7 +7,12 @@
 
 #set -x
 
-version="1.8.1"
+version="$(sed -ne 's/^version: *"\(.*\)\.git".*/\1/p' opam)"
+
+if test -z "$version"; then
+  echo "Internal error: failed to parse version number from opam file" 1>&2
+	exit 1
+fi
 
 # Remember the old IFS value:
 oldifs="$IFS"

--- a/findlib.files
+++ b/findlib.files
@@ -24,6 +24,7 @@
 # Exclusions must be mentioned before inclusions.
 
 f configure
+f opam
 f findlib.conf.in
 f INSTALL
 f LICENSE

--- a/opam
+++ b/opam
@@ -1,27 +1,37 @@
-opam-version: "1.2"
-maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
-author:       "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
-homepage:     "http://projects.camlcity.org/projects/findlib.html"
-bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
-dev-repo:     "https://gitlab.camlcity.org/gerd/lib-findlib.git"
-version:      "1.8.0.git"
-
+opam-version: "2.0"
+version: "1.8.1.git"
+synopsis: "A library manager for OCaml"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.
+"""
 build: [
-  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [
+    "./configure"
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-topfind" {ocaml:preinstalled}
+  ]
   [make "all"]
-  [make "opt"] { ocaml-native }
+  [make "opt"] {ocaml:native}
 ]
 install: [
   [make "install"]
-  ["cp" "ocaml-stub" "%{bin}%/ocaml"] {preinstalled}
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
-remove: [
-  ["ocamlfind" "remove" "bytes"]
-  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-topfind" {preinstalled}]
-  [make "uninstall"]
-  ["rm" "-f" "%{bin}%/ocaml"] {preinstalled}
-]
-available: [ocaml-version >= "3.12.0"] # ocamlfind refers to cmxs
 depends: [
+  "ocaml" {>= "4.00.0"} # ocamlfind uses String.map
   "conf-m4" {build}
 ]
+depopts: ["graphics"]

--- a/tools/extract_args/Makefile
+++ b/tools/extract_args/Makefile
@@ -1,7 +1,10 @@
 all: extract_args
 
+extract_args.ml: extract_args.mll
+	ocamllex -o $@ $<
+
 extract_args: extract_args.ml
-	ocamlc -o extract_args str.cma extract_args.ml
+	ocamlc -o extract_args extract_args.ml
 
 clean:
-	rm -f *.cmo *.cmi *.cma extract_args
+	rm -f *.cmo *.cmi *.cma extract_args extract_args.ml


### PR DESCRIPTION
It's always been possible to build OCaml without the Str library and since 4.08 it's even supported by `configure`. More importantly, as soon as `ocamldoc` leaves the OCaml distribution so will the Str library.

This PR:
- Updates the opam file to version 2.0 (referenced against the one in opam-repository).
- The version number in opam was "wrong" - I've updated it to "1.8.1.git" and also altered `configure` to take the version number from the opam file so that it isn't duplicated.
- Converts `tools/extract_args/extract_args.ml` into an ocamllex script (it produces identical output)