### PR TITLE
Fix BSD support

### DIFF
--- a/tools/extract_args/Makefile
+++ b/tools/extract_args/Makefile
@@ -1,7 +1,7 @@
 all: extract_args
 
 extract_args.ml: extract_args.mll
-	ocamllex -o $@ $<
+	ocamllex -o extract_args.ml extract_args.mll
 
 extract_args: extract_args.ml
 	ocamlc -o extract_args extract_args.ml


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18339#issuecomment-799731503

`$<` is non-standard Makefile and returns an empty string on BSDs