### PR TITLE
Install META files for the standard OCaml distribution atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ check-installation:
 
 .PHONY: install-meta
 install-meta:
-	for x in $(SITELIB_META); do mkdir -p "$(prefix)$(OCAML_SITELIB)/$$x"; cp site-lib-src/$$x/META "$(prefix)$(OCAML_SITELIB)/$$x"; done
+	for x in $(SITELIB_META); do mkdir -p "$(prefix)$(OCAML_SITELIB)/$$x"; cp site-lib-src/$$x/META "$(prefix)$(OCAML_SITELIB)/$$x/META.tmp" && mv "$(prefix)$(OCAML_SITELIB)/$$x/META.tmp" "$(prefix)$(OCAML_SITELIB)/$$x/META"; done
 	mkdir -p "$(prefix)$(OCAML_SITELIB)/findlib"; cp Makefile.packages "$(prefix)$(OCAML_SITELIB)/findlib/Makefile.packages"
 
 .PHONY: uninstall-meta


### PR DESCRIPTION
dune has the base packages builtin so ocamlfind is not required. However, when a META file is present dune reverts back to it. In this case, a race condition can occure on packages that for example uses `threads.posix` and is built at the same time as ocamlfind is installed. Such package would fail on some rare circonstances if the META file was in the middle of being copied