### PR TITLE
Add dll suffixes for macos.

### DIFF
--- a/src/findlib/findlib_config.mlp
+++ b/src/findlib/findlib_config.mlp
@@ -16,11 +16,11 @@ let libexec_name = "stublibs";;
 let system = "@SYSTEM@";;
 (* - "mingw", "mingw64", "win32", "cygwin", "linux_elf", ... *)
 
-let dll_suffix =
+let dll_suffixes =
   match Sys.os_type with
-      "Unix" -> ".so"
-    | "Win32" -> ".dll"
-    | "Cygwin" -> ".dll"
-    | "MacOS" -> ""        (* don't know *)
+      "Unix" -> [".so"]
+    | "Win32" -> [".dll"]
+    | "Cygwin" -> [".dll"]
+    | "MacOS" -> [".dylib"; ".so"]
     | _ -> failwith "Unknown Sys.os_type"
 ;;

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -267,8 +267,8 @@ let write_ldconf filename lines new_lines =
 
 
 let is_dll p =
-  let sfx = Findlib_config.dll_suffix in
-  sfx <> "" && Filename.check_suffix p sfx
+  let sfx = Findlib_config.dll_suffixes in
+  List.exists (Filename.check_suffix p) sfx
 ;;
 
 


### PR DESCRIPTION
In macOS, dynamic loaded library usually ends with `.dylib` but sometimes `.so` is used e.g. in the output files of `ocamlmklib`.