### PR TITLE
Adding constants for BeOS/Haiku platforms

### DIFF
--- a/src/findlib/findlib_config.mlp
+++ b/src/findlib/findlib_config.mlp
@@ -18,9 +18,8 @@ let system = "@SYSTEM@";;
 
 let dll_suffix =
   match Sys.os_type with
-      "Unix" -> ".so"
-    | "Win32" -> ".dll"
-    | "Cygwin" -> ".dll"
-    | "MacOS" -> ""        (* don't know *)
+    | "Unix"  | "BeOS"   -> ".so"
+    | "Win32" | "Cygwin" -> ".dll"
+    | "MacOS"            -> ""        (* don't know *)
     | _ -> failwith "Unknown Sys.os_type"
 ;;

--- a/src/findlib/fl_split.ml
+++ b/src/findlib/fl_split.ml
@@ -140,7 +140,7 @@ let norm_dir s =
     done
   in
   match Sys.os_type with
-      "Unix" | "Cygwin" -> norm_dir_unix(); Buffer.contents b
+      "Unix" | "BeOS" | "Cygwin" -> norm_dir_unix(); Buffer.contents b
     | "Win32" -> norm_dir_win(); Buffer.contents b
     | _ -> failwith "This os_type is not supported"
 ;;

--- a/src/findlib/fl_split.ml
+++ b/src/findlib/fl_split.ml
@@ -71,7 +71,7 @@ let is_valid_package_name s =
 
 let path_separator =
   match Sys.os_type with
-      "Unix"   -> ':'
+    | "Unix" | "BeOS"   -> ':'
     | "Cygwin" -> ';'   (* You might want to change this *)
     | "Win32"  -> ';'
     | "MacOS"  -> failwith "Findlib: I do not know what is the correct path separator for MacOS. If you can help me, write a mail to gerd@gerd-stolpmann.de"

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -1567,7 +1567,7 @@ let ocamldoc() =
 (* From ocamldep source code: *)
 let depends_on_char, continuation_char =
   match Sys.os_type with
-  | "Unix" | "Win32" | "Cygwin" -> ':', '\\'
+  | "Unix" | "BeOS" | "Win32" | "Cygwin" -> ':', '\\'
   | "MacOS" -> '\196', '\182'
   | _ -> assert false
 ;;


### PR DESCRIPTION
I also did a pull request to ocaml compiler to detect haiku/beos platforms. those new constants are consistant, and the change is innocuous to ocamlfind by the way.