### PR TITLE
support for OCaml 5

### DIFF
--- a/configure
+++ b/configure
@@ -589,6 +589,7 @@ fi
 # bytes?
 # (NB. This is always ours, and it doesn't go into generated_META)
 
+req_bytes=""
 if [ -f "${ocaml_core_stdlib}/bytes.cmi" -o \
      -f "${ocaml_core_stdlib}/stdlib__bytes.cmi" -o \
      -f "${ocaml_core_stdlib}/stdlib__Bytes.cmi" ]; then
@@ -598,6 +599,7 @@ if [ -f "${ocaml_core_stdlib}/bytes.cmi" -o \
 else
     echo "bytes: not found, installing compat library"
     lbytes=""
+    req_bytes="bytes"
     cbytes=1
 fi
 
@@ -637,7 +639,9 @@ done
 
 for part in `cd src; echo *`; do
     if [ -f "src/$part/META.in" ]; then
-	sed -e "s/@VERSION@/$version/g" src/$part/META.in >src/$part/META
+	sed -e "s/@VERSION@/$version/g" \
+            -e "s/@REQUIRES@/${req_bytes}/g" \
+            src/$part/META.in >src/$part/META
     fi
 done
 
@@ -665,11 +669,16 @@ fi
 # Write Makefile.config
 
 parts="findlib"
+ocamlfind_ocamlflags=""
+ocamlfind_archives="findlib.cma unix.cma"
 if [ $with_toolbox -gt 0 ]; then
     parts="$parts findlib-toolbox"
 fi
 if [ $cbytes -gt 0 ]; then
-    parts="$parts bytes"
+    # bytes first, because findlib needs it
+    parts="bytes $parts"
+    ocamlfind_ocamlflags="-I ../bytes"
+    ocamlfind_archives="bytes.cma ${ocamlfind_archives}"
 fi
 
 echo "# Makefile.config written by configure" >Makefile.config
@@ -681,6 +690,8 @@ echo "OCAML_THREADS=${ocaml_threads}" >>Makefile.config
 echo "OCAMLFIND_BIN=${ocamlfind_bin}" >>Makefile.config
 echo "OCAMLFIND_MAN=${ocamlfind_man}" >>Makefile.config
 echo "OCAMLFIND_CONF=${ocamlfind_config}" >>Makefile.config
+echo "OCAMLFIND_OCAMLFLAGS=${ocamlfind_ocamlflags}" >>Makefile.config
+echo "OCAMLFIND_ARCHIVES=${ocamlfind_archives}" >>Makefile.config
 echo "OCAML_AUTOLINK=${ocaml_autolink}" >>Makefile.config
 echo "OCAML_REMOVE_DIRECTORY=${have_remdir}" >>Makefile.config
 echo "EXEC_SUFFIX=${exec_suffix}" >>Makefile.config

--- a/mini/ocamlfind-mini
+++ b/mini/ocamlfind-mini
@@ -575,7 +575,7 @@ let copy_file ?(rename = (fun name -> name)) ?(append = "") src dstdir =
     let ch_out = open_out_bin outpath in
     try
       let buflen = 4096 in
-      let buf = String.create buflen in
+      let buf = Bytes.create buflen in
       let pos = ref 0 in
       let len = ref (input ch_in buf 0 buflen) in
       while !len > 0 do

--- a/opam
+++ b/opam
@@ -4,8 +4,8 @@ synopsis: "A library manager for OCaml"
 maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
-bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
-dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 description: """
 Findlib is a library manager for OCaml. It provides a convention how
 to store libraries, and a file format ("META") to describe the

--- a/src/bytes/Makefile
+++ b/src/bytes/Makefile
@@ -1,27 +1,28 @@
 BYTE_FILES=bytes.cmi bytes.cma
 NATIVE_FILES=bytes.cmx bytes$(LIB_SUFFIX) bytes.cmxa
 NATIVE_FILES_DYNLINK=bytes.cmxs
-OCAMLBUILD=ocamlbuild -classic-display -no-links
 
 TOP=../..
 include $(TOP)/Makefile.config
 
+OCAMLC = ocamlc
+OCAMLOPT = ocamlopt -g
+
 build: all opt
 
 all:
-	$(OCAMLBUILD) $(BYTE_FILES)
+	$(OCAMLC) -a -o bytes.cma bytes.ml
 
 opt:
-	files="$(NATIVE_FILES)"; \
-	if [ $(HAVE_NATDYNLINK) = 1 ]; then \
-	    files="$$files $(NATIVE_FILES_DYNLINK)"; \
-	fi; \
-	$(OCAMLBUILD) $$files
+	$(OCAMLOPT) -a -o bytes.cmxa bytes.ml
+	if [ $(HAVE_NATDYNLINK) -gt 0 ]; then \
+	    $(OCAMLOPT) -shared -o bytes.cmxs bytes.cmxa; \
+	fi
 
 install: all
 	mkdir -p "$(prefix)$(OCAML_SITELIB)/bytes"
-	cd _build/ && cp ../META $(BYTE_FILES) "$(prefix)$(OCAML_SITELIB)/bytes"
-	cd _build/ && for f in $(NATIVE_FILES) $(NATIVE_FILES_DYNLINK); do if [ -f "$$f" ]; then cp $$f "$(prefix)$(OCAML_SITELIB)/bytes"; fi; done
+	cp META $(BYTE_FILES) "$(prefix)$(OCAML_SITELIB)/bytes"
+	for f in $(NATIVE_FILES) $(NATIVE_FILES_DYNLINK); do if [ -f "$$f" ]; then cp $$f "$(prefix)$(OCAML_SITELIB)/bytes"; fi; done
 
 uninstall: 
 	rm -rf "$(prefix)$(OCAML_SITELIB)/bytes"
@@ -30,7 +31,7 @@ uninstall:
 # questionable here.
 
 install-self: all
-	cd _build/ && ocamlfind install bytes ../META $(BYTE_FILES) -optional $(NATIVE_FILES) $(NATIVE_FILES_DYNLINK)
+	ocamlfind install bytes META $(BYTE_FILES) -optional $(NATIVE_FILES) $(NATIVE_FILES_DYNLINK)
 
 uninstall-self:
 	ocamlfind remove bytes

--- a/src/findlib/META.in
+++ b/src/findlib/META.in
@@ -8,7 +8,7 @@ version = "@VERSION@"
 package "internal" (
   version = "@VERSION@"
   description = "Package manager"
-  requires = ""
+  requires = "@REQUIRES@"
   archive(byte) = "findlib.cma"
   archive(native) = "findlib.cmxa"
   plugin(byte) = "findlib.cma"

--- a/src/findlib/Makefile
+++ b/src/findlib/Makefile
@@ -32,6 +32,9 @@ TXOBJECTS      = topfind.cmx
 OCAMLFIND_OBJECTS = ocaml_args.cmo frontend.cmo
 OCAMLFIND_XOBJECTS = ocaml_args.cmx frontend.cmx
 
+# OCAMLFIND_ARCHIVES: set in Makefile.config
+OCAMLFIND_XARCHIVES = $(OCAMLFIND_ARCHIVES:.cma=.cmxa)
+
 NUMTOP_OBJECTS = num_top_printers.cmo num_top.cmo
 
 DYNLOAD_OBJECTS  = fl_dynload.cmo
@@ -47,12 +50,12 @@ opt: ocamlfind_opt$(EXEC_SUFFIX) findlib.cmxa findlib_top.cmxa topfind \
 num-top: num_top.cma
 
 ocamlfind$(EXEC_SUFFIX): findlib.cma $(OCAMLFIND_OBJECTS)
-	$(OCAMLC) $(CUSTOM) -o ocamlfind$(EXEC_SUFFIX) -g findlib.cma unix.cma \
-	          $(OCAMLC_FLAGS) $(OCAMLFIND_OBJECTS)
+	$(OCAMLC) $(CUSTOM) -o ocamlfind$(EXEC_SUFFIX) -g $(OCAMLFIND_ARCHIVES) \
+	          $(OCAMLC_FLAGS) $(OCAMLFIND_OCAMLFLAGS) $(OCAMLFIND_OBJECTS)
 
 ocamlfind_opt$(EXEC_SUFFIX): findlib.cmxa $(OCAMLFIND_XOBJECTS)
-	$(OCAMLOPT) -o ocamlfind_opt$(EXEC_SUFFIX) findlib.cmxa unix.cmxa \
-		  $(OCAMLOPT_FLAGS) $(OCAMLFIND_XOBJECTS)
+	$(OCAMLOPT) -o ocamlfind_opt$(EXEC_SUFFIX) $(OCAMLFIND_XARCHIVES) \
+		  $(OCAMLOPT_FLAGS) $(OCAMLFIND_OCAMLFLAGS) $(OCAMLFIND_XOBJECTS)
 
 test_parser$(EXEC_SUFFIX): fl_metascanner.cmx test_parser.cmx fl_metatoken.cmx fl_meta.cmx
 	$(OCAMLOPT) -o test_parser$(EXEC_SUFFIX) fl_meta.cmx fl_metatoken.cmx fl_metascanner.cmx test_parser.cmx
@@ -153,19 +156,19 @@ depend: *.ml *.mli fl_meta.ml fl_metascanner.ml findlib_config.ml topfind.ml
 # .src
 
 .mml.cmo:
-	$(OCAMLC) $(OPAQUE) -g -vmthread -c -impl $<
+	$(OCAMLC) $(OPAQUE) $(OCAMLC_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -g -vmthread -c -impl $<
 
 .mml.cmx:
-	$(OCAMLOPT) $(OPAQUE) -thread -c -impl $<
+	$(OCAMLOPT) $(OPAQUE) $(OCAMLOPT_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -thread -c -impl $<
 
 .ml.cmx:
-	$(OCAMLOPT) $(OPAQUE) -c $<
+	$(OCAMLOPT) $(OPAQUE) $(OCAMLOPT_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -c $<
 
 .ml.cmo:
-	$(OCAMLC) $(OPAQUE) -g -c $<
+	$(OCAMLC) $(OPAQUE)  $(OCAMLC_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -g -c $<
 
 .mli.cmi:
-	$(OCAMLC) $(OPAQUE) -c $<
+	$(OCAMLC) $(OPAQUE)  $(OCAMLC_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -c $<
 
 #.src.ml:
 #	$(CAMLP4O) -impl $< -o $@

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -1823,7 +1823,7 @@ let copy_file ?(rename = (fun name -> name)) ?(append = "") src dstdir =
 		   outpath in
     try
       let buflen = 4096 in
-      let buf = String.create buflen in   (* FIXME: Bytes.create *)
+      let buf = Bytes.create buflen in
       let pos = ref 0 in
       let len = ref (input ch_in buf 0 buflen) in
       while !len > 0 do


### PR DESCRIPTION
Closes #29 

`String.create` -> `Bytes.create`. Works even for very old ocaml versions (tested with 4.01.0) that do not provide the bytes type.