### PR TITLE
OCaml 5.00 support (take 2)

### DIFF
--- a/src/findlib/fl_metascanner.mli
+++ b/src/findlib/fl_metascanner.mli
@@ -7,6 +7,8 @@
 
 open Fl_metatoken
 
+exception Error of string
+
 type formal_pred =
     [ `Pred of string     (** Positive occurence of a formal predicate var *)
     | `NegPred of string  (** Negative occurence of a formal predicate var *)

--- a/src/findlib/fl_package_base.ml
+++ b/src/findlib/fl_package_base.ml
@@ -154,7 +154,7 @@ let packages_in_meta_file ?(directory_required = false)
       Failure s ->
 	close_in ch;
 	failwith ("While parsing '" ^ meta_file ^ "': " ^ s)
-    | Stream.Error s ->
+    | Error s ->
 	close_in ch;
 	failwith ("While parsing '" ^ meta_file ^ "': " ^ s)
     | any ->

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -2015,7 +2015,7 @@ let meta_pkg meta_name =
     pkg
   with
   | Failure s
-  | Stream.Error s ->
+  | Fl_metascanner.Error s ->
     close_in f;
     failwith ("Cannot parse '" ^ meta_name ^ "': " ^ s)
 


### PR DESCRIPTION
`Stream` was removed in https://github.com/ocaml/ocaml/pull/10896, thus making ocamlfind once again impossible to compile with trunk.

This simply creates a minimal implementation of `Stream`. I did my best to emulate the exact behaviour of `Stream` so there shouldn’t be any difference.