### PR TITLE
Make topfind directory initialisation lazy

### DIFF
--- a/src/findlib/topfind.ml.in
+++ b/src/findlib/topfind.ml.in
@@ -8,7 +8,8 @@ let predicates = ref ("toploop" :: Findlib.recorded_predicates());;
      Findlib, hence we maintain our own list
    *)
 
-let directories = ref [ Findlib.ocaml_stdlib() ];;
+let directories = 
+  Lazy.from_fun (fun () -> ref [ Findlib.ocaml_stdlib() ]);;
 
 
 (* Note: Sys.interactive is always _true_ during toploop startup.
@@ -43,6 +44,7 @@ let revised_syntax () = syntax "camlp4r";;
 
 let add_dir d =
   let d = Fl_split.norm_dir d in
+  let directories = Lazy.force directories in
   if not (List.mem d !directories) then begin
     Topdirs.dir_directory d;
     directories := d :: !directories;


### PR DESCRIPTION
This change allows Utop, and other projects that use `ocamlfind`, to be used in an environment where the standard library is not present at startup time.