### PR TITLE
Use OCaml spelling everywhere

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -134,7 +134,7 @@ now:
 
 mkdir `ocamlfind printconf destdir`/stublibs
 
-If you do this, you must also tell O'Caml that DLLs can be found in
+If you do this, you must also tell OCaml that DLLs can be found in
 this directory: Add the absolute path of this directory to
 the ld.conf file (type "ocamlfind printconf ldconf" to get the
 location of the ld.conf file). Every line of this text file lists
@@ -172,14 +172,14 @@ Even in cases (2) and (3)! That means use something like
 script, and therefore expects Cygwin input. At the right moment, the
 paths are back-translated to their Windows counterparts.
 
-Until O'Caml 3.08 you must specify whether you have (2) or (3) by
+Until OCaml 3.08 you must specify whether you have (2) or (3) by
 the configure switches
 
 - "-system mingw" for (2)
 - "-system win32" for (3)
 - nothing for (1)
 
-Since O'Caml 3.09 this is no longer necessary because "ocamlc -config"
+Since OCaml 3.09 this is no longer necessary because "ocamlc -config"
 outputs the required information.
 
 In previous versions of Findlib there was a single switch -cygpath 

--- a/Makefile.config.pattern
+++ b/Makefile.config.pattern
@@ -12,7 +12,7 @@ OCAML_CORE_MAN=/usr/local/man
 
 #----------------------------------------------------------------------
 # Type of multi-threading support: either vm or posix
-# (Note: Since O'Caml 3.07, "posix" includes "vm", because a build
+# (Note: Since OCaml 3.07, "posix" includes "vm", because a build
 # supporting posix also supports vm.)
 #----------------------------------------------------------------------
 OCAML_THREADS=vm

--- a/configure
+++ b/configure
@@ -384,8 +384,8 @@ fi
 ######################################################################
 # Does this version of OCaml support autolinking?
 
-# Works for O'Caml >= 3.00 on. Because findlib can only be compiled
-# with these O'Caml versions, we can safely assume that autolinking
+# Works for OCaml >= 3.00 on. Because findlib can only be compiled
+# with these OCaml versions, we can safely assume that autolinking
 # is enabled.
 
 ocaml_autolink="true"

--- a/doc/QUICKSTART.xml
+++ b/doc/QUICKSTART.xml
@@ -22,7 +22,7 @@ findlib.</p>
   <sect1>
     <title>Findlib and the toploop</title> 
 
-<p>For a number of platforms, O'Caml can load bytecode-compiled
+<p>For a number of platforms, OCaml can load bytecode-compiled
 libraries dynamically. For these platforms, findlib is very simple to
 use as explained in the following. For other platforms, see the paragraph
 below about "custom toploops".</p>
@@ -110,7 +110,7 @@ for the revised syntax. (But you cannot switch between the syntaxes.)
   <sect1>
     <title>Custom Toploops</title>
 
-    <p>For some platforms, O'Caml does not implement loading external
+    <p>For some platforms, OCaml does not implement loading external
 libraries (e.g. Cygwin). One has to create a so-called custom toploop
 that statically links with these libraries. Example:
 
@@ -167,7 +167,7 @@ open Cgi;;
 ...
 </code>
 
-This works wherever O'Caml is installed.</p>
+This works wherever OCaml is installed.</p>
   </sect1>
 
   <sect1>
@@ -265,8 +265,8 @@ a Makefile is written.
   <sect1>
     <title>There is no magic!</title>
 
-    <p>Findlib is neither a patch of O'Caml nor uses it internal features of
-the O'Caml programming environment. It is only a convention to install
+    <p>Findlib is neither a patch of OCaml nor uses it internal features of
+the OCaml programming environment. It is only a convention to install
 software components in filesystem hierarchies, a library interpreting 
 this convention, and some frontend applications making the library useable for
 you.</p>

--- a/doc/README.xml
+++ b/doc/README.xml
@@ -34,7 +34,7 @@ directly deal with packages.
 
     <p>It is important to understand that findlib is <em>not</em> a
 general-purpose package manager (like rpm for Linux), and does <em>not</em>
-support the management of arbitrary files, but only O'Caml libraries.
+support the management of arbitrary files, but only OCaml libraries.
 However, there are lots of special functions for libraries. findlib
 is more comparable with Gnome's pkg-config and Perl's MakeMaker, but
 of course there are language-specific differences.</p>
@@ -347,13 +347,13 @@ Ivanov for pointing this problem out.)</p>
       <p>ocamlfind no longer emits auto-generated -ccopt options. These
          tend to accumulate, and it is possible that for large projects
          the maximum command line length is exceeded. Current versions of
-         the O'Caml compilers do not need these extra -ccopt anyway, so
+         the OCaml compilers do not need these extra -ccopt anyway, so
          this code is completely dropped.</p>
     </li>
 
     <li>
       <p><em>1.2.4:</em> Fix: Bigarray needs unix (Thanks to Markus Mottl).</p>
-      <p>Fix: In the version of camlp4 provided by O'Caml 3.11 various
+      <p>Fix: In the version of camlp4 provided by OCaml 3.11 various
          libraries do not contain dynlink anymore. Because of this, dynlink
          becomes a prerequisite of camlp4. (Thanks to Martin Jambon).</p>
       <p>Attempt: Fixing the space issue for paths (Win32). It is unclear
@@ -390,7 +390,7 @@ when installing safe_camlp4 (thanks to Daniel Janus)</p>
 Pietro Abate)</p>
 	<p>Better support for Windows (with help from Robert
 Roessler and David Allsopp)</p>
-	<p>Support for camlp4 on O'Caml 3.10</p>
+	<p>Support for camlp4 on OCaml 3.10</p>
 	<p>Fix: "ocamlfind install" with "-patch" option writes
 now correct META file for the case that subpackages occur</p>
 	<p>Adding environment variable OCAMLFIND_IGNORE_DUPS_IN
@@ -407,7 +407,7 @@ DLLs.</p>
 
       <li>
 	<p><em>1.1.1:</em> Bugfixes only: Fixed detection of threading model
-for O'Caml 3.09. Fixed alternate configuration files.</p>
+for OCaml 3.09. Fixed alternate configuration files.</p>
       </li>
 
       <li>
@@ -527,12 +527,12 @@ takes predicates into account (it did not do that in previous versions of
 findlib).</p>
       </li>
 
-      <li><p><em>0.9:</em> Changes for O'Caml 3.07 (-thread,
+      <li><p><em>0.9:</em> Changes for OCaml 3.07 (-thread,
       -vmthread). Includes Zack's toploop printers for bigints.</p>
       </li>
 
       <li><p><em>0.8 - 0.8.1:</em> Renamed a lot of modules to avoid name
-	clashes with O'Caml core modules.  Cygwin: Additional option
+	clashes with OCaml core modules.  Cygwin: Additional option
 	-cygpath for "configure".  The man pages have a NAME
 	section. Bugfix in Makefile wizard.</p>
       </li>
@@ -579,7 +579,7 @@ findlib).</p>
 	does not occur.</p>
 
 	<p>Fix: bytecode threads work again. (The wrong unix library was
-	linked for recent O'Caml versions.)</p>
+	linked for recent OCaml versions.)</p>
 
 	<p>Many smaller improvements; the docs have been updated.</p>
       </li>
@@ -611,7 +611,7 @@ findlib).</p>
 	<p>Optional alternate directory layout: All META files go into
 	a separate directory (see documentation under site-lib).</p>
 
-	<p>Findlib works now only for O'Caml 3; support for O'Caml 2 has been
+	<p>Findlib works now only for OCaml 3; support for OCaml 2 has been
 	dropped. As a consequence, the "configure" script could be
 	simplified; it is no longer necessary to figure out the
 	linker options.</p>
@@ -628,7 +628,7 @@ findlib).</p>
 	functionality, but it is sufficient to compile and install a
 	library. (But it does not support using a library.)</p>
 
-	<p>Support for the Cygwin port of O'Caml.</p>
+	<p>Support for the Cygwin port of OCaml.</p>
 
 	<p>Installation of packages: The file permissions are
 	preserved when files are installed.  However, the umask is
@@ -655,7 +655,7 @@ findlib).</p>
 	</p>
       </li>
 
-      <li><p><em>0.3 - 0.3.1:</em> Necessary updates for O'Caml
+      <li><p><em>0.3 - 0.3.1:</em> Necessary updates for OCaml
 3. Bugfix: Findlib did not work for bytecode threads. The reason was
 that findlib added the directory of the stdlib to the search
 path. Works now.

--- a/doc/src/findlib.sgml
+++ b/doc/src/findlib.sgml
@@ -189,14 +189,14 @@ In the following, we are only analyzing the problem of making and
 using libraries from a purely software-technical point of view. This
 means, we ignore how to make functions polymorphic, and how to create
 functors and classes. Instead, we only look at how to invoke the
-O'Caml compiler to create, manage, and use libraries. Especially, we
+OCaml compiler to create, manage, and use libraries. Especially, we
 are interested in the administration of systems of libraries that
 have dependencies.</para>
 
 <para>
 One of the complex operations on such a system is the replacement of 
 a library by a newer version. Because of the strict compatibility
-checks of O'Caml, it is usually necessary to rebuild and reinstall
+checks of OCaml, it is usually necessary to rebuild and reinstall
 all dependent libraries as well. With the help of findlib, one can
 find out which are the dependent libraries. (However, findlib does
 not provide a framework to rebuild them. For example, the GODI
@@ -1037,7 +1037,7 @@ thread implementation is selected.
 
 <listitem>
 <para>
-autolink: The predicate "autolink" is set if the O'Caml compiler can perform
+autolink: The predicate "autolink" is set if the OCaml compiler can perform
 automatic linking. This predicate is never set if the -noautolink option is
 in effect.
 </para>
@@ -1055,7 +1055,7 @@ in effect.
 <title>Dynamic toploops</title>
 
 <para>
-Recent versions of O'Caml support dynamic loading of stub libraries
+Recent versions of OCaml support dynamic loading of stub libraries
 (but only for the more widely used operating systems). This means
 that one can start a toploop by running
 
@@ -1067,7 +1067,7 @@ $ ocaml
 </programlisting>
 
 and that it is now possible to load .cma archive files referring to
-shared C libraries ("DLLs"). In older versions of O'Caml this was
+shared C libraries ("DLLs"). In older versions of OCaml this was
 not possible and one had to create a so-called custom toploop
 with the ocamlmktop command. This method is still supported and 
 explained below; however, nowadays it is often not necessary to
@@ -2069,14 +2069,14 @@ override the setting in the generated "Makefile".)
 <title>FAQs</title>
 
 <sect1>
-<title>Does findlib support the autolink feature of O'Caml 3?</title>
+<title>Does findlib support the autolink feature of OCaml 3?</title>
 
 <para>
 <emphasis>Short answer:</emphasis> Findlib is compatible with autolink
 </para>
 
 <para>
-The new archive format introduced with O'Caml 3 can store the linker options
+The new archive format introduced with OCaml 3 can store the linker options
 that are necessary to link an archive. For example:
 
 <programlisting>
@@ -2103,7 +2103,7 @@ because findlib should keep the compatibility with older software, and because
 </para>
 
 <para>
-If you have software that must run in both O'Caml 2 and O'Caml 3 environments,
+If you have software that must run in both OCaml 2 and OCaml 3 environments,
 you can make your "linkopts" attribute dependent on the "autolink"
 predicate. For example:
 
@@ -2112,9 +2112,9 @@ linkopts = "-cclib -lmylibrary"
 linkopts(autolink) = ""
 </programlisting>
 
-The findlib installation for O'Caml 3 will take the second line which is
+The findlib installation for OCaml 3 will take the second line which is
 reasonable because ocamlc already knows how to link; the installation for
-O'Caml 2 never sets the "autolink" predicate and therefore uses the first line.
+OCaml 2 never sets the "autolink" predicate and therefore uses the first line.
 </para>
       </sect1>
 
@@ -2331,7 +2331,7 @@ ocamlfind ocamlc -package yourname -syntax variant ...
 	  <title>Example</title>
 
 <para>The package <literal>xstrp4</literal> defines a syntax extension allowing
-$-substitutions in O'Caml strings. Version 1.0 of this package takes advantage
+$-substitutions in OCaml strings. Version 1.0 of this package takes advantage
 from the new camlp4 support of findlib; you may have a look at it for an
 example.</para>
 

--- a/doc/src/findlib_conf.mod
+++ b/doc/src/findlib_conf.mod
@@ -39,7 +39,7 @@ There are three possibilities to configure the findlib library:
 
     <listitem>
     <para>
-    Whether the installed O'Caml version supports autolinking or not.
+    Whether the installed OCaml version supports autolinking or not.
     </para>
     </listitem>
 
@@ -230,7 +230,7 @@ ocamlmktop = "ocamlmktop.opt"
   <term><literal>stdlib</literal></term>
   <listitem><para>
     This variable determines the location of the standard library. This must
-    be the same directory for which the O'Caml compilers are configured.
+    be the same directory for which the OCaml compilers are configured.
   </para>
 
   <para>
@@ -246,14 +246,14 @@ ocamlmktop = "ocamlmktop.opt"
   <term><literal>ldconf</literal></term>
   <listitem><para>
     This variable determines the location of the ld.conf file. This must
-    be the same file the O'Caml compilers read in; it is updated by 
+    be the same file the OCaml compilers read in; it is updated by 
     ocamlfind when installing and removing packages. You can set this
     variable to the special value "<literal>ignore</literal>" to disable
     the automatic modification of the ld.conf file.
   </para>
 
   <para>
-    If not set, the ld.conf file is assumed to reside in the O'Caml
+    If not set, the ld.conf file is assumed to reside in the OCaml
     standard library directory.
   </para>
 

--- a/doc/src/findlib_ocamlfind.mod
+++ b/doc/src/findlib_ocamlfind.mod
@@ -643,13 +643,13 @@ knows automatic linking (from version 3.00), but it is not set if the
 </varlistentry>
 <varlistentry>
   <term>camlp4o</term>
-  <listitem><para>This is the reserved predicate for the standard O'Caml syntax.
+  <listitem><para>This is the reserved predicate for the standard OCaml syntax.
   It can be used in the <literal>-syntax</literal> predicate list.
   </para></listitem>
 </varlistentry>
 <varlistentry>
   <term>camlp4r</term>
-  <listitem><para>This is the reserved predicate for the revised O'Caml syntax.
+  <listitem><para>This is the reserved predicate for the revised OCaml syntax.
   It can be used in the <literal>-syntax</literal> predicate list.
   </para></listitem>
 </varlistentry>
@@ -704,7 +704,7 @@ You can use extended names: (1) With <literal>-I</literal> options,
 <refsect2>
 <title>How to set the names of the compiler executables</title>
 
-<para> Normally, the O'Caml bytecode compiler can be called under the name
+<para> Normally, the OCaml bytecode compiler can be called under the name
 <literal>ocamlc</literal>. However, this is not always true; sometimes a
 different name is chosen.</para>
 
@@ -798,7 +798,7 @@ ocamlfind ocamldep [-package <replaceable>package-name-list</replaceable> |
 <refsect2><title>Description</title>
 <para>
 This command is a driver for the tool <literal>ocamldep</literal> of the
-O'Caml distribution. This driver is only useful in conjunction with
+OCaml distribution. This driver is only useful in conjunction with
 the preprocessor camlp4; otherwise it does not provide more functions
 than <literal>ocamldep</literal> itself.
 </para>

--- a/mini/README
+++ b/mini/README
@@ -2,7 +2,7 @@
 ocamlfind-mini
 ----------------------------------------------------------------------
 
-ocamlfind-mini is an O'Caml script that implements a subset of the
+ocamlfind-mini is an OCaml script that implements a subset of the
 full functionality of ocamlfind. It consists only of one file, so it
 is easy to distribute it with any software.
 

--- a/src/findlib-toolbox/make_wizard.ml
+++ b/src/findlib-toolbox/make_wizard.ml
@@ -1007,8 +1007,8 @@ let intro_screen frame =
   add_headline frame "The Makefile and META wizard";
   add_para frame "This wizard helps you creating Makefiles and META \
 files for simple projects. It assumes that all your source files \
-reside in a single directory, and that all source files are O'Caml \
-files (no support for mixed O'Caml/C projects). ocamllex, ocamlyacc, \
+reside in a single directory, and that all source files are OCaml \
+files (no support for mixed OCaml/C projects). ocamllex, ocamlyacc, \
 and camlp4 are supported.";
   add_para frame "The wizard generates a Makefile, and the Makefile \
 produces the META file. The Makefile is not perfect, and is not the ideal \
@@ -1547,7 +1547,7 @@ mainLoop();;
  * 	Renamed modules (prefix fl_)
  *
  * Revision 1.2  2002/07/29 19:52:23  gerd
- * 	Fixes for O'Caml 3.05
+ * 	Fixes for OCaml 3.05
  *
  * Revision 1.1  2002/05/26 14:09:07  gerd
  * 	Renaming


### PR DESCRIPTION
According to the [FAQ](https://v2.ocaml.org/learn/faq.html#General-Questions) it is spelled OCaml, so to be consistent I replaced all references to O'Caml with the officially preferred spelling.