### PR TITLE
Add runtime_events otherlib

### DIFF
--- a/configure
+++ b/configure
@@ -518,6 +518,7 @@ check_library ocamlbuild 'normal since 4.03' ocamlbuild/ocamlbuildlib.cma
 check_library ocamldoc '' ocamldoc/odoc.cmi
 check_library raw_spacetime 'normal since 4.12' raw_spacetime_lib.cmxa
 check_library threads '' threads/thread.cmi vmthreads/thread.cmi;
+check_library runtime_events ''
 
 # Need to know if str and labltk are available for the toolbox
 if check_library str 'possible since 4.08'; then

--- a/findlib.files
+++ b/findlib.files
@@ -90,6 +90,9 @@ f site-lib-src/threads/interfaces.in
 d site-lib-src/unix
 f site-lib-src/unix/META.in
 f site-lib-src/unix/interfaces.in
+d site-lib-src/runtime_events
+f site-lib-src/runtime_events/META.in
+f site-lib-src/runtime_events/interfaces.in
 d site-lib-src/ocamlbuild
 f site-lib-src/ocamlbuild/META.in
 d site-lib-src/ocamldoc

--- a/site-lib-src/runtime_events/META.in
+++ b/site-lib-src/runtime_events/META.in
@@ -1,0 +1,11 @@
+# Specifications for the "runtime_events" library:
+requires = ""
+description = "Runtime events"
+version = "[distributed with OCaml]"
+directory = "^"
+browse_interfaces = "%%interfaces%%"
+archive(byte) = "runtime_events.cma"
+archive(native) = "runtime_events.cmxa"
+plugin(byte) = "runtime_events.cma"
+plugin(native) = "runtime_events.cmxs"
+

--- a/site-lib-src/runtime_events/interfaces.in
+++ b/site-lib-src/runtime_events/interfaces.in
@@ -1,0 +1,1 @@
+runtime_events.cma


### PR DESCRIPTION
This PR is to support OCaml 5's new `Runtime_events` "otherlib" if/when it gets merged https://github.com/ocaml/ocaml/pull/10964