### PR TITLE
Make reading of `ocaml_stdlib` configuration lazy

### DIFF
--- a/src/findlib/topfind.ml.in
+++ b/src/findlib/topfind.ml.in
@@ -8,7 +8,8 @@ let predicates = ref ("toploop" :: Findlib.recorded_predicates());;
      Findlib, hence we maintain our own list
    *)
 
-let directories = ref [ Findlib.ocaml_stdlib() ];;
+let directories = 
+  Lazy.from_fun (fun () -> ref [ Findlib.ocaml_stdlib() ]);;
 
 
 (* Note: Sys.interactive is always _true_ during toploop startup.
@@ -43,6 +44,7 @@ let revised_syntax () = syntax "camlp4r";;
 
 let add_dir d =
   let d = Fl_split.norm_dir d in
+  let directories = Lazy.force directories in
   if not (List.mem d !directories) then begin
     Topdirs.dir_directory d;
     directories := d :: !directories;

--- a/src/findlib/topfind.ml.in
+++ b/src/findlib/topfind.ml.in
@@ -8,8 +8,8 @@ let predicates = ref ("toploop" :: Findlib.recorded_predicates());;
      Findlib, hence we maintain our own list
    *)
 
-let directories = 
-  Lazy.from_fun (fun () -> ref [ Findlib.ocaml_stdlib() ]);;
+let ocaml_stdlib = Lazy.from_fun Findlib.ocaml_stdlib;;
+let directories = ref [ ] ;;
 
 
 (* Note: Sys.interactive is always _true_ during toploop startup.
@@ -44,8 +44,8 @@ let revised_syntax () = syntax "camlp4r";;
 
 let add_dir d =
   let d = Fl_split.norm_dir d in
-  let directories = Lazy.force directories in
-  if not (List.mem d !directories) then begin
+  let lazy ocaml_stdlib = ocaml_stdlib in
+  if d <> ocaml_stdlib && not (List.mem d !directories) then begin
     Topdirs.dir_directory d;
     directories := d :: !directories;
     !log (d ^ ": added to search path")


### PR DESCRIPTION
Supersedes #39 and applies @dra27 suggestions. I'm opening a new PR because I don't have permission to push on @patricoferris's fork.