### PR TITLE
Fix bug when installing with a system compiler (and without coreutils)

### DIFF
--- a/src/findlib/Makefile
+++ b/src/findlib/Makefile
@@ -123,7 +123,7 @@ clean:
 install: all
 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/$(NAME)"
 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAMLFIND_BIN)"
-	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
+	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
 	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)/"
 	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config \
 	findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib$(LIB_SUFFIX) findlib.cmxs \


### PR DESCRIPTION
See https://discuss.ocaml.org/t/problem-installing-ocamlfind-on-latest-ocamlpro-alpine-docker-image/10147