### PR TITLE
Reflect OCaml 3.08+ requirement in `opam` file

### DIFF
--- a/opam
+++ b/opam
@@ -33,4 +33,7 @@ install: [
   [make "install"]
   ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
+depends: [
+  "ocaml" {>= "3.08.0"}
+]
 depopts: ["graphics"]


### PR DESCRIPTION
This doesn't affect the 1.9.6 release (heck, I hope it only affects museum users!). opam packages ocamlfind 1.0.4 for the OCaml 3.07 switches, so it's "worth" having the lowerbound constraint 🙂