### PR TITLE
Fix opam upgrade to ocamlfind 1.9.6 for OCaml 5.x

### DIFF
--- a/configure
+++ b/configure
@@ -297,7 +297,7 @@ if [ $ocaml_major -ge 5 ]; then
     # If findlib has been configured -sitelib $(ocamlc -where) then there's
     # nothing to do, but otherwise we need to put OCaml's Standard Library
     # into the path setting.
-    if [ ! -e "${ocaml_sitelib}/stdlib/META" ]; then
+    if [ ! -e "${ocaml_sitelib}/stdlib.cmi" ]; then
         ocamlpath="${ocaml_core_stdlib}${path_sep}${ocamlpath}"
     fi
 fi


### PR DESCRIPTION
A compatibility check in the `configure` script when dealing with OCaml 5's preconfigured `META` files is failing in opam when _upgrading_ from ocamlfind 1.9.5.

The test is supposed to ensure that if `ocamlfind` has been configured with `-sitelib $(ocamlc -where)` then it doesn't add `ocamlc -where` to `ocamlpath` (this reflects OS-distributed ocamlfind, IIRC).

Rather than risking string comparison of paths, the test for whether `-sitelib` is `$(ocamlc -where)` is done by looking `${ocaml_sitelib}/stdlib/META`. Unfortunately, in an opam switch with OCaml 5 and ocamlfind 1.9.5 already installed, `-sitelib` is the `$(opam var lib)` and `${ocaml_sitelib}/stdlib/META` will be the ocamlfind 1.9.5 `META` causing this test to fail.

The effect is that this sequence:

```
opam switch create 5.0 ocaml-base-compiler.5.0.0
opam install ocamlfind.1.9.5
opam install ocamlfind.1.9.6
ocamlfind list
```
will not include any of the OCaml findlib packages (`unix`, etc.).

The fix is simple, and can be carried in an ocamlfind.1.9.6-1 package in opam.