### PR TITLE
Fix configuration process on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -289,6 +289,9 @@ if [ -z "$ocaml_sitelib" ]; then
 fi
 
 ocamlpath="${ocaml_sitelib}"
+if [ ${use_cygpath} -gt 0 ]; then
+    cygpath_to_unix ocamlpath
+fi
 if [ $ocaml_major -ge 5 ]; then
     # OCaml 5.0+ installs its own META files under the stdlib directory.
     # If findlib has been configured -sitelib $(ocamlc -where) then there's

--- a/tools/patch
+++ b/tools/patch
@@ -9,7 +9,7 @@ varvalue="$2"
 if [ "${USE_CYGPATH}" = "1" ]; then
     #varvalue="$(echo "$varvalue" | sed -e 's;/;\\;g')"
     varvalue="$(cygpath -w -l $3 "$varvalue")"
-    varvalue="$(echo "$varvalue" | sed -e 's;\\;\\\\\\\\;g')"
+    varvalue="$(echo "$varvalue" | sed -e 's;\\;\\\\\\\\;g;s/;/\\;/g')"
     # e.g. c:\file is transformed to c:\\\\file
 else
     case `uname` in


### PR DESCRIPTION
`$ocamlpath` wasn't going through enough conversions in `configure` (one path is processed with `cygpath`, the other wasn't). Additionally, on Windows the PATH separator is `;` and so with Windows OCaml 5 this was breaking one of the sed calls in `tools/patch`, since that uses `;` as the sed parameter separator.