### PR TITLE
Fix warning 6 (labels-omitted)

### DIFF
--- a/src/findlib/findlib.ml
+++ b/src/findlib/findlib.ml
@@ -385,15 +385,15 @@ let package_property predlist pkg propname =
 ;;
 
 
-let package_ancestors predlist pkg =
+let package_ancestors preds pkg =
   lazy_init();
-  Fl_package_base.requires predlist pkg
+  Fl_package_base.requires ~preds pkg
 ;;
 
 
-let package_deep_ancestors predlist pkglist =
+let package_deep_ancestors preds pkglist =
   lazy_init();
-  Fl_package_base.requires_deeply predlist pkglist
+  Fl_package_base.requires_deeply ~preds pkglist
 ;;
 
 

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -856,7 +856,7 @@ let query_package () =
     let eff_packages =
       if !recursive then begin
         if !descendants then
-          Fl_package_base.package_users predicates1 packages1
+          Fl_package_base.package_users ~preds:predicates1 packages1
         else
           package_deep_ancestors predicates1 packages1
       end


### PR DESCRIPTION
When compiling with a recent OCaml version (4.14.1 in this case) warning 6 is enabled which warns about function application without the label.

Example:

```
File "fl_package_base.ml", line 304, characters 22-40:
304 | 	 let pkg_ancestors = query_requirements predlist pkg in
      	                     ^^^^^^^^^^^^^^^^^^
Warning 6 [labels-omitted]: label preds was omitted in the application of this function.
```

This commit adds the labels (and renames anonymous arguments to allow labels to match names wherever convenient).