### PR TITLE
Remove `.mml` references

### DIFF
--- a/src/findlib/Makefile
+++ b/src/findlib/Makefile
@@ -118,7 +118,7 @@ num_top.cma: $(NUMTOP_OBJECTS)
 
 clean:
 	rm -f *.cmi *.cmo *.cma *.cmx *.a *.lib *.o *.obj *.cmxa \
-	  fl_meta.ml findlib_config.ml findlib.mml topfind.ml topfind \
+	  fl_meta.ml findlib_config.ml topfind.ml topfind \
 	  ocamlfind$(EXEC_SUFFIX) ocamlfind_opt$(EXEC_SUFFIX)
 
 install: all
@@ -161,14 +161,8 @@ depend: *.ml *.mli fl_meta.ml fl_metascanner.ml findlib_config.ml topfind.ml
 
 # Some 'make' implementations require that .SUFFIXES must occur before
 # the first suffix rule. (E.g. AIX)
-.SUFFIXES: .mll .cmo .cmi .cmx .ml .mli .mml
+.SUFFIXES: .mll .cmo .cmi .cmx .ml .mli
 # .src
-
-.mml.cmo:
-	$(OCAMLC) $(OPAQUE) $(OCAMLC_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -g -vmthread -c -impl $<
-
-.mml.cmx:
-	$(OCAMLOPT) $(OPAQUE) $(OCAMLOPT_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -thread -c -impl $<
 
 .ml.cmx:
 	$(OCAMLOPT) $(OPAQUE) $(OCAMLOPT_FLAGS) $(OCAMLFIND_OCAMLFLAGS) -c $<


### PR DESCRIPTION
I was looking to modify the Makefile and wondered what `.mml` is. It doesn't seem to be used and removing it didn't create any issues that I could see, hence this PR.

There is no `findlib.mml` nor does anything seem to create it or compile it, so it seems this is a leftover of some thread/vmthread code that doesn't exist anymore.