### PR TITLE
Disable various parts of -thread handling for 5.x

### DIFF
--- a/src/findlib/findlib_config.mlp
+++ b/src/findlib/findlib_config.mlp
@@ -3,6 +3,11 @@
  *
  *)
 
+let ocaml_has_meta_files =
+  let ocaml_major =
+    String.sub Sys.ocaml_version 0 (String.index Sys.ocaml_version '.') in
+  int_of_string ocaml_major >= 5;;
+
 let config_file = "@CONFIGFILE@";;
 
 let ocaml_stdlib = "@STDLIB@";;

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -1100,7 +1100,8 @@ let ocamlc which () =
 	  predicates := "mt" :: "mt_vm" :: !predicates;
 
       | `POSIX_threads ->
-	  pass_options := !pass_options @ [ "-thread" ];
+          if not Findlib_config.ocaml_has_meta_files then
+	    pass_options := !pass_options @ [ "-thread" ];
 	  predicates := "mt" :: "mt_posix" :: !predicates;
   );
 
@@ -1253,7 +1254,11 @@ let ocamlc which () =
 	tr Sys.remove (Filename.chop_extension initl_file_name ^ ".cmo");
       );
 
-  let exclude_list = [ stdlibdir; threads_dir; vmthreads_dir ] in
+  let exclude_list =
+    if Findlib_config.ocaml_has_meta_files then
+      [ stdlibdir ]
+    else
+      [ stdlibdir; threads_dir; vmthreads_dir ] in
   (* Don't generate -I options for these directories because there is
    * also some magic in ocamlc/ocamlopt that would not work otherwise
    *)
@@ -1311,7 +1316,8 @@ let ocamlc which () =
              else
                [] in
 	   let pkg_dir =
-	     if pkg = "threads" then   (* MAGIC *)
+	     if not Findlib_config.ocaml_has_meta_files && pkg = "threads" then
+	       (* MAGIC for pre-5.x days *)
 	       match !threads with
 		   `None -> stdlibdir
 		 | `VM_threads -> vmthreads_dir


### PR DESCRIPTION
Implements a fix for an [issue reported in Discuss](https://discuss.ocaml.org/t/14344).

The original example, given `a.ml`:

```ocaml
let x = Thread.self ()
```

is that this command (despite being incorrect) works in 3.x/4.x:
```console
$ ocamlfind ocamlopt -I +unix -I +threads -package threads -linkpkg unix.cmxa threads.cmxa a.ml
ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
```

but in 5.x:
```console 
$ ocamlfind ocamlopt -I +unix -I +threads -package threads -linkpkg unix.cmxa threads.cmxa a.ml
File "a.ml", line 1:
Error: Cannot find file /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/threads.cmxa
```

This command isn't directly fixable, as the fix to ensure that `threads.cmxa` is linked from `/home/dra/.opam/fix-threads-5.1.1/lib/ocaml/threads/threads.cmxa` will then result in double-linking.

However, if we consider the correct invocation, which for `ocamlfind` should _always_ involve `-thread` to set **ocamlfind**'s machinery into the correct mode:

```console 
$ ocamlfind ocamlopt -package threads -linkpkg -thread a.ml -verbose
Effective set of compiler predicates: pkg_unix,pkg_threads,autolink,mt,mt_posix,native
+ ocamlopt.opt -verbose -thread -I /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/unix /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/unix/unix.cmxa /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/threads/threads.cmxa a.ml
```

In 5.x, this is linking without warning, but the invocation is incorrect as it's relying on the _deprecated in ocamlopt_ `-thread` option and effectively ignoring the `META` file for threads shipped with OCaml 5.

With this PR, that then becomes:

```console
Effective set of compiler predicates: pkg_unix,pkg_threads,autolink,mt,mt_posix,native
+ ocamlopt.opt -verbose -I /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/unix -I /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/threads /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/unix/unix.cmxa /home/dra/.opam/fix-threads-5.1.1/lib/ocaml/threads/threads.cmxa a.ml
```

and we can see the correct set of predicates, combined with standard `-I` and `.cmxa` parameters for packages. The command works with or without the `-thread` argument to `ocamlfind`, the flag now controls whether the `mt` and `mt_posix` predicates are true. My recollection when preparing https://github.com/ocaml/ocaml/pull/11007 was that the `mt` and `mt_posix` predicates were not used outside of findlib itself (i.e. that there are not (m)any third-party META files which uses these two predciates)