### PR TITLE
Fix autodetection of -opaque and -g

### DIFF
--- a/configure
+++ b/configure
@@ -437,7 +437,7 @@ ocaml -I +compiler-libs itest-aux/ppx.ml >/dev/null || {
 echo "Checking for ocamlc -opaque..."
 
 opaque="-opaque"
-ocamlc -opaque >/dev/null 2>/dev/null || opaque=""
+ocamlc -opaque -version >/dev/null 2>/dev/null || opaque=""
 
 ######################################################################
 # Check for ocamlopt -g
@@ -445,7 +445,7 @@ ocamlc -opaque >/dev/null 2>/dev/null || opaque=""
 echo "Checking for ocamlopt -g..."
 
 native_debugging_info="-g"
-ocamlopt -g >/dev/null 2>/dev/null || native_debugging_info=""
+ocamlopt -g -version >/dev/null 2>/dev/null || native_debugging_info=""
 
 ######################################################################
 # Configure libraries


### PR DESCRIPTION
The autodetection of whether `-opaque` and `-g` are supported by the compiler is broken since OCaml 5.2 (as debugged by @emillon in issue #78), because now `ocamlc -opaque` gives an error even though the `-opaque` flag is supported.

This patch changes the tested command to be `ocamlc -opaque -version` (which succeeds if `-opaque` is supported and fails if not, even on recent OCaml), and likewise for `-g`.
