### PR TITLE
[fl_dynload] Allow overriding low-level module loader

### DIFF
--- a/doc/README.xml
+++ b/doc/README.xml
@@ -110,6 +110,14 @@ configuration files, and library routines in detail.</p>
     <ul>
 
       <li>
+        <p><em>1.9.7:</em>: Allow overriding low-level module loader
+        in `Fl_dynload.load_packages`. This is very useful in JSOO
+        where we may want to implement a `.cma` -> `.js` cache instead
+        of calling `Dynlink.loadfile` dynamically. (Emilio J. Gallego
+        Arias).</p>
+      </li>
+
+      <li>
         <p><em>1.9.6:</em>: Support for OCaml-5 (as far as foreseeable)
         (David Allsopp).</p>
         <p>Again buildable since OCaml-3.08 (David Allsopp).</p>

--- a/src/findlib/fl_dynload.ml
+++ b/src/findlib/fl_dynload.ml
@@ -4,7 +4,7 @@
 
 open Printf
 
-let load_pkg ~debug pkg =
+let load_pkg ~debug ~loadfile pkg =
   if not (Findlib.is_recorded_package pkg) then (
      if debug then
        eprintf "[DEBUG] Fl_dynload: about to load: %s\n%!" pkg;
@@ -34,12 +34,12 @@ let load_pkg ~debug pkg =
      let files = Fl_split.in_words archive in
      if debug then
        eprintf "[DEBUG] Fl_dynload: files=%S\n%!" archive;
-     List.iter 
+     List.iter
        (fun file ->
           if debug then
             eprintf "[DEBUG] Fl_dynload: loading %S\n%!" file;
           let file = Findlib.resolve_path ~base:d file in
-          Dynlink.loadfile file
+          loadfile file
        ) files;
      Findlib.record_package Findlib.Record_load pkg
   )
@@ -48,8 +48,8 @@ let load_pkg ~debug pkg =
       eprintf "[DEBUG] Fl_dynload: not loading: %s\n%!" pkg
 
 
-let load_packages ?(debug=false) pkgs =
+let load_packages ?(debug=false) ?(loadfile=Dynlink.loadfile) pkgs =
   let preds = Findlib.recorded_predicates() in
   let eff_pkglist =
     Findlib.package_deep_ancestors preds pkgs in
-  List.iter (load_pkg ~debug) eff_pkglist
+  List.iter (load_pkg ~debug ~loadfile) eff_pkglist

--- a/src/findlib/fl_dynload.mli
+++ b/src/findlib/fl_dynload.mli
@@ -2,7 +2,7 @@
 
 (** Utilities for loading dynamically packages *)
 
-val load_packages : ?debug:bool -> string list -> unit
+val load_packages : ?debug:bool -> ?loadfile:(string -> unit) -> string list -> unit
 (** Load the given packages and all their dependencies dynamically. Packages
     already loaded or already in-core are not loaded again. The predicates
     are taken from {!Findlib.recorded_predicates}, which are normally the


### PR DESCRIPTION
Before this patch, `Fl_dynload.load_packages` will unconditionally call `Dynlink.loadfile` to load each particular compilation unit.

This works fine in almost all our scenarios, however when compiling Web Workers with JSOO, we have found that `Dynlink.loadfile` takes a very long time as it will compile `.cma` files to `.js`.

In the case of jsCoq and `coq-lsp` this compilation process is too heavy. Prior to us using `findlib`, we used to trap all calls from Coq to `Dynlink.loadfile`, and we used a pre-compiled `.js` version which was much much faster.

This patch makes it possible for users of `Fl_dynload.load_packages` to override the call to `Dynlink.loadfile` as to for example implement the above cache setup, or to do other kinds of instrumentations.