### PR TITLE
Don't enable the `-with-relative-paths-at` in opam

### DIFF
--- a/opam
+++ b/opam
@@ -22,7 +22,6 @@ build: [
     "-sitelib" lib
     "-mandir" man
     "-config" "%{lib}%/findlib.conf"
-    "-with-relative-paths-at" prefix
     "-no-custom"
     "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}


### PR DESCRIPTION
cf. https://github.com/ocaml/opam-repository/pull/26864#pullrequestreview-2433196198.

The setup using an environment variable is clearly beneficial to Dune's experimental package management feature, but I don't think it's a good thing to turn on at present for _all_ opam-repository users (especially given both @MSoegtropIMC and @jonahbeckford's concerns). It causes `ocamlfind` to depend on the `OPAM_SWITCH_PREFIX` environment variable being correct, which at present it does not. Given that opam itself can't do any kind of caching or relocation (at least at present), it doesn't seem to bring any benefit with that increased brittleness.

cc @Leonidas-from-XIV - there are a couple of mechanisms available which could allow this option to be enabled explicitly by a user, if it would be helpful for Dune p.m.? (very happy to help with that).