### PR TITLE
set OCAMLOPT_SHARED when building "bytes" replacement

### DIFF
--- a/src/bytes/Makefile
+++ b/src/bytes/Makefile
@@ -7,6 +7,7 @@ include $(TOP)/Makefile.config
 
 OCAMLC = ocamlc
 OCAMLOPT = ocamlopt $(OCAMLOPT_G)
+OCAMLOPT_SHARED = $(OCAMLOPT)
 
 build: all opt
 


### PR DESCRIPTION
Closes #89 