### PR TITLE
Fix the exception to catch when `threads` is not available

### DIFF
--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -922,7 +922,7 @@ let ocamlc which () =
 
   let type_of_threads =
     try package_property [] "threads" "type_of_threads"
-    with Not_found -> "ignore"
+    with No_such_package _ -> "ignore"
   in
   let threads_default =
     match type_of_threads with


### PR DESCRIPTION
This PR simply fixes the exception that should be caught when `threads` is not available.

When the compiler is configured with `--disable-systhreads`, we get:
```
$ ocamlfind ocamlopt -config
ocamlfind: Package `threads' not found
```
because the exception that is raised when the lookup fails has been changed without updating the handler.
The issue has been reported in #67 in one use case but the failure is a lot more general than that. It came up in particular in mirage/ocaml-solo5#148.

This PR comes with a CI workflow that shows that the command now works and that was used to ensure first that it was failing as described above before the fix: see the [log](https://github.com/shym/ocamlfind/actions/runs/13548218485/job/37865073864) while it last. I’m not sure whether it would be useful as-is.