### PR TITLE
Fix `FINDLIB_PATH` when using relative paths

### DIFF
--- a/configure
+++ b/configure
@@ -741,7 +741,14 @@ if [ $cbytes -gt 0 ]; then
     ocamlfind_archives="bytes.cma ${ocamlfind_archives}"
 fi
 
-relative_site_lib=$(echo "${ocaml_sitelib}" | sed -e "s#^${ocaml_prefix}#\$PREFIX#")
+case "${ocaml_sitelib}" in
+  "${ocaml_prefix}"*)
+    relative_site_lib='$$PREFIX'"${ocaml_sitelib#"${ocaml_prefix}"}"
+    ;;
+  *)
+    relative_site_lib="${ocaml_sitelib}"
+    ;;
+esac
 
 if [ $with_relative_paths -gt 0 ]; then
     # if configured with relative paths we add the relative path to the search path
@@ -772,7 +779,7 @@ fi
     echo "PARTS=${parts}"
     echo "INSTALL_TOPFIND=${with_topfind}"
     echo "RELATIVE_PATHS=${relative_paths}"
-    echo "RELATIVE_OCAML_SITELIB=${relative_site_lib}" | sed -e "s/\\\$/\$\$/"
+    echo "RELATIVE_OCAML_SITELIB=${relative_site_lib}"
     echo "USE_CYGPATH=${use_cygpath}"
     echo "HAVE_NATDYNLINK=${have_natdynlink}"
     echo "VERSION=${version}"


### PR DESCRIPTION
Fix the generation of the relative site lib path so that both `destdir` and `path` start with a `$PREFIX/lib`.

Before that patch, running:

```
./configure -bindir $OPAM_SWITCH_PREFIX/bin -sitelib $OPAM_SWITCH_PREFIX/lib -mandir $OPAM_SWITCH_PREFIX/man -config $OPAM_SWITCH_PREFIX/lib/findlib.conf -with-relative-paths-at $OPAM_SWITCH_PREFIX -no-custom -no-camlp4
make -B findlib.conf
```

yielded a broken `path`:

```
path="REFIX/lib:..."
```

`configure` has been tested with `dash`, `bash` and `busybox sh`; the 'info' reported by `shellcheck` is indeed correct.