### PR TITLE
Update the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,15 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
-      # Check building with make
-      - run: |
+      - name: Build with make
+        run: |
           opam exec -- ${{ runner.os == 'Windows' && 'sh ' || '' }}./configure
           opam exec -- make all opt
 
-      # Check installing with opam
-      - run: opam pin add ocamlfind .
+      - name: Build and install with opam
+        run: opam pin add ocamlfind .
 
-      # Test it
-      - run: opam exec -- ocamlfind list
-      - run: opam exec -- ocaml .github/workflows/toplist.ml
+      - name: Test the ocamlfind binary
+        run: opam exec -- ocamlfind list
+      - name: Test the toplevel plugin
+        run: opam exec -- ocaml .github/workflows/toplist.ml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         run: opam pin add ocamlfind .
 
       - name: Test the ocamlfind binary
-        run: opam exec -- ocamlfind list
+        env:
+          OPT: ${{ matrix.ocaml-version == '3.08' && '-version' || '-config' }}
+        run: |
+          opam exec -- ocamlfind list
+          opam exec -- ocamlfind printconf
+          opam exec -- ocamlfind opt ${{ env.OPT }}
+
       - name: Test the toplevel plugin
         run: opam exec -- ocaml .github/workflows/toplist.ml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set-up OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v3


### PR DESCRIPTION
This PR updates a few points of the CI workflow:

- it updates the version of `actions/checkout` to avoid a warning due to the deprecation of v4,
- it add names to the various steps to make the logs easier to read,
- it tests some other sub-commands of the `ocamlfind` binary.

Those extra tests are pulled off #99.