### PR TITLE
Make paths from ld.conf absolute

### DIFF
--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -226,23 +226,30 @@ let use_package prefix pkgnames =
 ;;
 
 
-let read_ldconf filename =
+let read_ldconf ldconf_filename =
   let lines = ref [] in
-  let f = open_in filename in
+  let f = open_in ldconf_filename in
   try
     while true do
       let line = input_line f in
       if line <> "" then
-	lines := line :: !lines
+        lines := line :: !lines
     done;
     assert false
   with
-      End_of_file ->
-	close_in f;
-	List.rev !lines
-    | other ->
-	close_in f;
-	raise other
+  | End_of_file ->
+      close_in f;
+      let make_absolute path =
+        if Filename.is_relative path then
+          let dir = Filename.dirname ldconf_filename in
+          Filename.concat dir path
+        else
+          path
+      in
+      List.rev_map make_absolute !lines
+  | other ->
+      close_in f;
+      raise other
 ;;
 
 


### PR DESCRIPTION
This fixes https://github.com/ocaml/ocamlfind/issues/115 by making relative paths contained in a read `ld.conf` file absolute (by making them relative to the directory holding the `ld.conf` file). This is necessary for reading the `ld.conf` file that is installed by OCaml 5.5.0, which on current opam switch contains:
```
../stublibs
./stublibs
.
```

Note however that this will lead to the following paths with this PR, since no normalization is performed.
```
$OPAM_SWTCH_PREFIX/lib/ocaml/../stublibs
$OPAM_SWTCH_PREFIX/lib/ocaml/./stublibs
$OPAM_SWTCH_PREFIX/lib/ocaml/.
```

I believe this could have implications for parts of the system that deal with installing / uninstalling packages, but it could well be that things are fine if the paths are always consistent. In any case, I'm not sure the install/uninstall features are widely used now that most packages rely on dune.