### PR TITLE
Windows build fixes (MSYS2, Cygwin, etc.)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 # Default behaviour, for if core.autocrlf isn't set
 * text=auto
- text eol=lf
 /ocaml-stub  text eol=lf
 /release text eol=lf
 /itest text eol=lf
 /configure text eol=lf
 /mini/ocamlfind-mini text eol=lf
+/tools/cmd_in_different_dirs text eol=lf
 /tools/file_exists text eol=lf
 /tools/safe_camlp4 text eol=lf
 /tools/make-package-macosx text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: ${{ matrix.os }} - OCaml ${{ matrix.ocaml-version }}
+    name: ${{ matrix.os.windows_environment == '' && matrix.os.name || format('windows-latest/{0}', matrix.os.windows_environment) }} - OCaml ${{ matrix.ocaml-version }}
 
     strategy:
       fail-fast: false
@@ -12,17 +12,21 @@ jobs:
       # OCaml versions.
       matrix:
         os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
+          - name: macos-latest
+          - name: ubuntu-latest
+          - name: windows-latest
+            windows_environment: cygwin
+          - name: windows-latest
+            windows_environment: msys2
         ocaml-version:
           - "4.14"
           - "5.4"
         include:
-          - os: ubuntu-latest
+          - os:
+              name: ubuntu-latest
             ocaml-version: "3.08"
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.name }}
 
     steps:
       - name: Checkout code
@@ -32,6 +36,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
+          windows-environment: ${{ matrix.os.windows_environment == '' && 'cygwin' || matrix.os.windows_environment }}
           opam-repositories: |
             default: git+https://github.com/ocaml/opam-repository.git
             archive: git+https://github.com/ocaml/opam-repository-archive.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         ocaml-version:
           - "4.14"
           - "5.4"
+          - "5.5"
         include:
           - os:
               name: ubuntu-latest
@@ -44,6 +45,9 @@ jobs:
       - name: Build with make
         run: |
           opam exec -- ${{ runner.os == 'Windows' && 'sh ' || '' }}./configure
+          echo ------------
+          grep "[\\\\/]" Makefile.config
+          echo ------------
           opam exec -- make all opt
 
       - name: Build and install with opam
@@ -54,8 +58,12 @@ jobs:
           OPT: ${{ matrix.ocaml-version == '3.08' && '-version' || '-config' }}
         run: |
           opam exec -- ocamlfind list
+          echo ------------
           opam exec -- ocamlfind printconf
+          echo ------------
           opam exec -- ocamlfind opt ${{ env.OPT }}
+          echo ------------
+          opam exec -- ocamlfind printconf conf | tr -d '\r' | tr '\\' '/' | xargs cat
 
       - name: Test the toplevel plugin
         run: opam exec -- ocaml .github/workflows/toplist.ml

--- a/.github/workflows/toplist.ml
+++ b/.github/workflows/toplist.ml
@@ -1,2 +1,8 @@
 #use "topfind";;
 #list;;
+#require "findlib";;
+let () =
+  let ld_conf = Findlib.ocaml_ldconf () in
+  let print_line = Printf.printf "  %s\n" in
+  Printf.printf "Reading %s\n" ld_conf;
+  List.iter print_line (Findlib.read_ldconf ld_conf);;

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ META
 
 Makefile.config
 Makefile.packages
+findlib.conf.in
 findlib.conf
 ocargs.log
 src/findlib/depend

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.cmxs
 *.a
 *.so
+*.exe
 META
 
 Makefile.config

--- a/Makefile
+++ b/Makefile
@@ -50,34 +50,14 @@ README: doc/README
 .PHONY: all-config
 all-config: findlib.conf
 
-.PHONY: findlib-template
-findlib-template: findlib.conf.in
+findlib.conf: findlib.conf.in
 	{ \
-	  USE_CYGPATH="$(USE_CYGPATH)"; \
-	  export USE_CYGPATH; \
-	  cat findlib.conf.in | \
-	      $(SH) tools/patch '@SITELIB@' '$(FINDLIB_OCAML_SITELIB)' | \
-	      $(SH) tools/patch '@FINDLIB_PATH@' '$(FINDLIB_PATH)' -p; \
+	  cat $<; \
 	  ./tools/cmd_in_different_dirs ocamlc || echo 'ocamlc="ocamlc.opt"'; \
 	  ./tools/cmd_in_different_dirs ocamlopt || echo 'ocamlopt="ocamlopt.opt"'; \
 	  ./tools/cmd_in_different_dirs ocamldep || echo 'ocamldep="ocamldep.opt"'; \
 	  ./tools/cmd_in_different_dirs ocamldoc || echo 'ocamldoc="ocamldoc.opt"'; \
 	} > $@
-
-.PHONY: findlib-relative
-findlib-relative: FINDLIB_OCAML_SITELIB=$(RELATIVE_OCAML_SITELIB)
-findlib-relative: findlib-template
-
-.PHONY: findlib-absolute
-findlib-absolute: FINDLIB_OCAML_SITELIB=$(OCAML_SITELIB)
-findlib-absolute: findlib-template
-
-findlib.conf: findlib.conf.in
-	if [ "$(RELATIVE_PATHS)" = "true" ]; then \
-	  $(MAKE) findlib-relative; \
-        else \
-	  $(MAKE) findlib-absolute; \
-	fi
 
 .PHONY: install-doc
 install-doc:

--- a/Makefile
+++ b/Makefile
@@ -52,23 +52,17 @@ all-config: findlib.conf
 
 .PHONY: findlib-template
 findlib-template: findlib.conf.in
-	USE_CYGPATH="$(USE_CYGPATH)"; \
-	export USE_CYGPATH; \
-	cat findlib.conf.in | \
-	    $(SH) tools/patch '@SITELIB@' '$(FINDLIB_OCAML_SITELIB)' | \
-			$(SH) tools/patch '@FINDLIB_PATH@' '$(FINDLIB_PATH)' -p >findlib.conf
-	if ./tools/cmd_from_same_dir ocamlc; then \
-		echo 'ocamlc="ocamlc.opt"' >>findlib.conf; \
-	fi
-	if ./tools/cmd_from_same_dir ocamlopt; then \
-		echo 'ocamlopt="ocamlopt.opt"' >>findlib.conf; \
-	fi
-	if ./tools/cmd_from_same_dir ocamldep; then \
-		echo 'ocamldep="ocamldep.opt"' >>findlib.conf; \
-	fi
-	if ./tools/cmd_from_same_dir ocamldoc; then \
-		echo 'ocamldoc="ocamldoc.opt"' >>findlib.conf; \
-	fi
+	{ \
+	  USE_CYGPATH="$(USE_CYGPATH)"; \
+	  export USE_CYGPATH; \
+	  cat findlib.conf.in | \
+	      $(SH) tools/patch '@SITELIB@' '$(FINDLIB_OCAML_SITELIB)' | \
+	      $(SH) tools/patch '@FINDLIB_PATH@' '$(FINDLIB_PATH)' -p; \
+	  ./tools/cmd_in_different_dirs ocamlc || echo 'ocamlc="ocamlc.opt"'; \
+	  ./tools/cmd_in_different_dirs ocamlopt || echo 'ocamlopt="ocamlopt.opt"'; \
+	  ./tools/cmd_in_different_dirs ocamldep || echo 'ocamldep="ocamldep.opt"'; \
+	  ./tools/cmd_in_different_dirs ocamldoc || echo 'ocamldoc="ocamldoc.opt"'; \
+	} > $@
 
 .PHONY: findlib-relative
 findlib-relative: FINDLIB_OCAML_SITELIB=$(RELATIVE_OCAML_SITELIB)

--- a/Makefile.config.pattern
+++ b/Makefile.config.pattern
@@ -7,8 +7,6 @@
 # Where the OCAML core is installed:
 #----------------------------------------------------------------------
 OCAML_CORE_STDLIB=/usr/local/lib/ocaml
-OCAML_CORE_BIN=/usr/local/bin
-OCAML_CORE_MAN=/usr/local/man
 
 #----------------------------------------------------------------------
 # Type of multi-threading support: either vm or posix

--- a/Makefile.config.pattern
+++ b/Makefile.config.pattern
@@ -7,6 +7,7 @@
 # Where the OCAML core is installed:
 #----------------------------------------------------------------------
 OCAML_CORE_STDLIB=/usr/local/lib/ocaml
+OCAML_CORE_STDLIB_NATIVE=$(OCAML_CORE_STDLIB)
 
 #----------------------------------------------------------------------
 # Type of multi-threading support: either vm or posix
@@ -20,11 +21,7 @@ OCAML_THREADS=vm
 # Where the site-lib directory will be
 #----------------------------------------------------------------------
 OCAML_SITELIB=/usr/local/lib/ocaml/site-lib
-
-#----------------------------------------------------------------------
-# What the path setting will be
-#----------------------------------------------------------------------
-FINDLIB_PATH=/usr/local/lib/ocaml/site-lib:/usr/local/lib/ocaml
+OCAML_SITELIB_NATIVE=$(OCAML_SITELIB)
 
 #----------------------------------------------------------------------
 # Where binaries and manual pages will be installed
@@ -36,6 +33,7 @@ OCAMLFIND_MAN=/usr/local/man
 # The absolute location of the configuration file
 #----------------------------------------------------------------------
 OCAMLFIND_CONF=/usr/local/etc/ocamlfind.conf
+OCAMLFIND_CONF_NATIVE=$(OCAMLFIND_CONF)
 
 #----------------------------------------------------------------------
 # Autolinking is usually on
@@ -68,7 +66,6 @@ INSTALL_TOPFIND=1
 # installation
 #----------------------------------------------------------------------
 RELATIVE_PATHS=0
-RELATIVE_OCAML_SITELIB=$$PREFIX/lib
 
 #----------------------------------------------------------------------
 # Whether make install should update Makefile.packages just before

--- a/configure
+++ b/configure
@@ -754,8 +754,6 @@ fi
 {
     echo "# Makefile.config written by configure"
     echo "OCAML_CORE_STDLIB=${ocaml_core_stdlib}"
-    echo "OCAML_CORE_BIN=${ocaml_core_bin}"
-    echo "OCAML_CORE_MAN=${ocaml_core_man}"
     echo "OCAML_SITELIB=${ocaml_sitelib}"
     echo "FINDLIB_PATH=${ocamlpath}"
     echo "OCAML_THREADS=${ocaml_threads}"

--- a/configure
+++ b/configure
@@ -698,6 +698,19 @@ if [ $with_toolbox -gt 0 ]; then
     fi
 fi
 
+parts="findlib"
+ocamlfind_ocamlflags="-I +unix -I +dynlink"
+ocamlfind_archives="findlib.cma unix.cma"
+if [ $with_toolbox -gt 0 ]; then
+    parts="$parts findlib-toolbox"
+fi
+if [ $cbytes -gt 0 ]; then
+    # bytes first, because findlib needs it
+    parts="bytes $parts"
+    ocamlfind_ocamlflags="${ocamlfind_ocamlflags} -I ../bytes"
+    ocamlfind_archives="bytes.cma ${ocamlfind_archives}"
+fi
+
 # Generate the META files now.
 
 for dir in site-lib-src/*; do
@@ -727,12 +740,13 @@ for lib in $generated_META $lbytes; do
     echo "Configuration for $lib written to site-lib-src/$lib/META"
 done
 
-# create META from META.in in POSIX-compatible & safe way
-# see: https://www.shellcheck.net/wiki/SC2044
-meta_subst="sed -e 's/@VERSION@/$version/g' \
-	-e 's/@REQUIRES@/${req_bytes}/g' \
-	\"\$1\" > \"\${1%.in}\""
-find src -name 'META.in' -type f -exec sh -c "$meta_subst" sh {} \;
+for part in $parts; do
+  if [ -f src/"$part"/META.in ]; then
+    sed -e "s/@VERSION@/$version/g" \
+        -e "s/@REQUIRES@/${req_bytes}/g" \
+        src/"$part"/META.in > src/"$part"/META
+  fi
+done
 
 ######################################################################
 
@@ -754,19 +768,6 @@ fi
 
 ######################################################################
 # Write Makefile.config
-
-parts="findlib"
-ocamlfind_ocamlflags="-I +unix -I +dynlink"
-ocamlfind_archives="findlib.cma unix.cma"
-if [ $with_toolbox -gt 0 ]; then
-    parts="$parts findlib-toolbox"
-fi
-if [ $cbytes -gt 0 ]; then
-    # bytes first, because findlib needs it
-    parts="bytes $parts"
-    ocamlfind_ocamlflags="${ocamlfind_ocamlflags} -I ../bytes"
-    ocamlfind_archives="bytes.cma ${ocamlfind_archives}"
-fi
 
 relative_site_lib=$(echo "${ocaml_sitelib}" | sed -e "s#^${ocaml_prefix}#\$PREFIX#")
 

--- a/configure
+++ b/configure
@@ -3,6 +3,8 @@
 # ----------------------------------------------------------------------
 #
 
+set -e
+
 # Some functions
 
 #set -x
@@ -567,16 +569,16 @@ if ! check_library unix 'possible since 4.08' unix/unix.cmi unix.cmi; then
     exit 1
 fi
 
-check_library dynlink '' dynlink/dynlink.cmi dynlink.cmi
-check_library bigarray 'possible since 4.08'
-check_library compiler-libs '' 'compiler-libs'
-check_library dbm 'normal since 4.00'
-check_library graphics 'normal since 4.09'
-check_library num 'normal since 4.06'
-check_library ocamlbuild 'normal since 4.03' ocamlbuild/ocamlbuildlib.cma
-check_library ocamldoc '' ocamldoc/odoc.cmi
-check_library raw_spacetime 'normal since 4.12' raw_spacetime_lib.cmxa
-check_library threads '' threads/thread.cmi vmthreads/thread.cmi;
+check_library dynlink '' dynlink/dynlink.cmi dynlink.cmi || true
+check_library bigarray 'possible since 4.08' || true
+check_library compiler-libs '' 'compiler-libs' || true
+check_library dbm 'normal since 4.00' || true
+check_library graphics 'normal since 4.09' || true
+check_library num 'normal since 4.06' || true
+check_library ocamlbuild 'normal since 4.03' ocamlbuild/ocamlbuildlib.cma || true
+check_library ocamldoc '' ocamldoc/odoc.cmi || true
+check_library raw_spacetime 'normal since 4.12' raw_spacetime_lib.cmxa || true
+check_library threads '' threads/thread.cmi vmthreads/thread.cmi || true
 
 # Need to know if str and labltk are available for the toolbox
 if check_library str 'possible since 4.08' str/str.cmi str.cmi; then

--- a/configure
+++ b/configure
@@ -250,15 +250,19 @@ if [ -z "$system" ]; then
 fi
 
 path_sep=':'
+dir_sep='/'
 case "$system" in
     mingw|mingw64)
 	if [ "$pure_mingw" = "no" ];  then
 	    # CYGWIN
 	    use_cygpath=1
 	fi
-	;;
-    win32) use_cygpath=1;;
-    win64) use_cygpath=1;;
+	path_sep=';'
+	dir_sep="\\";;
+    win32|win64)
+	use_cygpath=1
+	path_sep=';'
+	dir_sep="\\";;
     # A quirk of history means OCAMLPATH uses ; on Cygwin
     cygwin) path_sep=';';;
 esac
@@ -273,41 +277,45 @@ fi
 ######################################################################
 # Find out standard library location
 
-ocaml_core_stdlib=$(get_stdlib)
-ocaml_major="$(ocamlc -vnum 2>/dev/null | cut -f1 -d.)"
-if [ ! -d "$ocaml_core_stdlib" ]; then
-   echo "configure: cannot determine ocaml's standard library directory" 1>&2
-    exit 1
-fi
-if [ -z "$ocaml_major" ]; then ocaml_major=3; fi
-
+ocaml_core_stdlib_native=$(get_stdlib)
+ocaml_core_stdlib="$ocaml_core_stdlib_native"
 if [ ${use_cygpath} -gt 0 ]; then
     cygpath_to_unix ocaml_core_stdlib
     # This makes ocaml_core_stdlib a Unix-type path
 fi
+if [ ! -d "$ocaml_core_stdlib" ]; then
+   echo "configure: cannot determine ocaml's standard library directory" 1>&2
+    exit 1
+fi
+ocaml_major="$(ocamlc -vnum 2>/dev/null | cut -f1 -d.)"
+if [ -z "$ocaml_major" ]; then ocaml_major=3; fi
 
 # Set site-lib directory:
 
 if [ -z "$ocaml_sitelib" ]; then
     case "$ocaml_core_stdlib" in
 	/opt/*)		ocaml_sitelib=$(dirname "${ocaml_core_stdlib}")/site-lib
+			ocaml_sitelib_native="$(dirname "$ocaml_core_stdlib_native")${dir_sep}site-lib"
 			;;
 	*)		ocaml_sitelib="${ocaml_core_stdlib}/site-lib"
+			ocaml_sitelib_native="${ocaml_core_stdlib_native}${dir_sep}site-lib"
 			;;
     esac
+else
+    ocaml_sitelib_native="$ocaml_sitelib"
+    if [ ${use_cygpath} -gt 0 ]; then
+        cygpath_to_unix ocaml_sitelib
+    fi
 fi
 
-ocamlpath="${ocaml_sitelib}"
-if [ ${use_cygpath} -gt 0 ]; then
-    cygpath_to_unix ocamlpath
-fi
+ocamlpath="${ocaml_sitelib_native}"
 if [ "$ocaml_major" -ge 5 ]; then
     # OCaml 5.0+ installs its own META files under the stdlib directory.
     # If findlib has been configured -sitelib $(ocamlc -where) then there's
     # nothing to do, but otherwise we need to put OCaml's Standard Library
     # into the path setting.
     if [ ! -e "${ocaml_sitelib}/stdlib.cmi" ]; then
-        ocamlpath="${ocaml_core_stdlib}${path_sep}${ocamlpath}"
+        ocamlpath="${ocaml_core_stdlib_native}${path_sep}${ocamlpath}"
     fi
 fi
 
@@ -319,6 +327,9 @@ ocaml_core_bin=$(dirname "${ocamlc}")
 # Set the directory of ocamlfind:
 
 test -n "$ocamlfind_bin" || ocamlfind_bin="$ocaml_core_bin"
+if [ ${use_cygpath} -gt 0 ]; then
+    cygpath_to_unix ocamlfind_bin
+fi
 
 # Find the directory for the manual:
 
@@ -354,6 +365,9 @@ done
 # Set the directory for ocamlfind's manuals:
 
 test -n "$ocamlfind_man" || ocamlfind_man="$ocaml_core_man"
+if [ ${use_cygpath} -gt 0 ]; then
+    cygpath_to_unix ocamlfind_man
+fi
 
 # Guess the right directory for the configuration file:
 
@@ -372,6 +386,17 @@ if [ -z "${ocamlfind_config}" ]; then
 	    # Fallback value
 	    ;;
     esac
+    ocamlfind_config_native="$ocamlfind_config"
+    # The guessing was done using Unix notation, so convert the path back to
+    # native notation (use_cygpath=0 for the Cygwin port)
+    if [ ${use_cygpath} -gt 0 ]; then
+	ocamlfind_config_native="$(cygpath -w "$ocamlfind_config")"
+    fi
+else
+    ocamlfind_config_native="$ocamlfind_config"
+    if [ ${use_cygpath} -gt 0 ]; then
+	cygpath_to_unix ocamlfind_config
+    fi
 fi
 
 ######################################################################
@@ -619,7 +644,7 @@ else
         fi
         camlp4_dir=$(camlp4 -where | tr -d '\r')
         if [ ${use_cygpath} -gt 0 ]; then
-            camlp4_dir=$(echo x | env USE_CYGPATH=1 tools/patch x "$camlp4_dir")
+            camlp4_dir=$(cygpath -w "$camlp4_dir" | sed -e 's;\\;\\\\;g')
             # This makes camlp4_dir a windows path
         elif [ "${pure_mingw}" = "yes" ]; then
             # Must double the backslahes
@@ -756,12 +781,14 @@ fi
 {
     echo "# Makefile.config written by configure"
     echo "OCAML_CORE_STDLIB=${ocaml_core_stdlib}"
+    echo "OCAML_CORE_STDLIB_NATIVE=${ocaml_core_stdlib_native}"
     echo "OCAML_SITELIB=${ocaml_sitelib}"
-    echo "FINDLIB_PATH=${ocamlpath}"
+    echo "OCAML_SITELIB_NATIVE=${ocaml_sitelib_native}"
     echo "OCAML_THREADS=${ocaml_threads}"
     echo "OCAMLFIND_BIN=${ocamlfind_bin}"
     echo "OCAMLFIND_MAN=${ocamlfind_man}"
     echo "OCAMLFIND_CONF=${ocamlfind_config}"
+    echo "OCAMLFIND_CONF_NATIVE=${ocamlfind_config_native}"
     echo "OCAMLFIND_OCAMLFLAGS=${ocamlfind_ocamlflags}"
     echo "OCAMLFIND_ARCHIVES=${ocamlfind_archives}"
     echo "OCAML_AUTOLINK=${ocaml_autolink}"
@@ -772,8 +799,6 @@ fi
     echo "PARTS=${parts}"
     echo "INSTALL_TOPFIND=${with_topfind}"
     echo "RELATIVE_PATHS=${relative_paths}"
-    echo "RELATIVE_OCAML_SITELIB=${relative_site_lib}" | sed -e "s/\\\$/\$\$/"
-    echo "USE_CYGPATH=${use_cygpath}"
     echo "HAVE_NATDYNLINK=${have_natdynlink}"
     echo "VERSION=${version}"
     echo "ENABLE_TOPFIND_PPXOPT=${enable_topfind_ppxopt}"
@@ -793,6 +818,14 @@ fi
     echo "INSTALLFILE = install -c"
     echo "# change to INSTALLFILE = cp   when BSD install is unavailable"
 } > Makefile.config
+{
+    if [ $with_relative_paths -gt 0 ]; then
+	echo "destdir=\"$(echo "${relative_site_lib}" | sed -e 's;\\;\\\\;g')\""
+    else
+	echo "destdir=\"$(echo "${ocaml_sitelib_native}" | sed -e 's;\\;\\\\;g')\""
+    fi
+    echo "path=\"$(echo "$ocamlpath" | sed -e 's;\\;\\\\;g')\""
+} > findlib.conf.in
 
 echo "SITELIB_META=${generated_META}" >Makefile.packages
 

--- a/configure
+++ b/configure
@@ -69,7 +69,7 @@ get_stdlib () {
     # Older versions of ocamlc do not accept -where, so there is a fallback
     # method:
     ocamlc -where 2>/dev/null | tr -d '\r' || {
-	ocamlc -v | sed -n -e "/Standard library directory/s/.*: \(.*\)/\1/p"; }
+	ocamlc -v | tr -d '\r' | sed -n -e "/Standard library directory/s/.*: \(.*\)/\1/p"; }
 }
 
 
@@ -683,7 +683,7 @@ done
 for lib in $generated_META $lbytes; do
     if=""
     if [ -f site-lib-src/"$lib"/interfaces.out ]; then
-        if=$(cat site-lib-src/"$lib"/interfaces.out)
+        if=$(cat site-lib-src/"$lib"/interfaces.out | tr -d '\r')
     fi
     sed \
         -e "s|%%type_of_threads%%|${ocaml_threads}|g" \

--- a/configure
+++ b/configure
@@ -105,7 +105,7 @@ get_lib_file () {
 cygpath_to_unix () {
     v=$1
     eval "p=\"\$$v\""
-    p="$(cygpath -w -s "$p")"
+    p="$(cygpath -w "$p")"
     p="$(cygpath -u "$p")"
     eval "$v=\"$p\""
 }

--- a/configure
+++ b/configure
@@ -210,7 +210,6 @@ lib_suffix=$(ocamlc -config 2>/dev/null | tr -d '\r' | sed -n -e 's/^ext_lib: //
 # Check for Cygwin:
 
 exec_suffix=
-pure_mingw="no"
 case $(uname) in
   CYGWIN*)
     exec_suffix=.exe
@@ -222,7 +221,6 @@ case $(uname) in
     ;;
   MINGW*)
     exec_suffix=.exe
-    pure_mingw="yes"
     echo "MinGW build environment found; using .exe as suffix for binaries"
     ;;
   *)
@@ -249,14 +247,7 @@ fi
 path_sep=':'
 dir_sep='/'
 case "$system" in
-    mingw|mingw64)
-	if [ "$pure_mingw" = "no" ];  then
-	    # CYGWIN
-	    use_cygpath=1
-	fi
-	path_sep=';'
-	dir_sep="\\";;
-    win32|win64)
+    mingw|mingw64|win32|win64)
 	use_cygpath=1
 	path_sep=';'
 	dir_sep="\\";;
@@ -643,9 +634,6 @@ else
         if [ ${use_cygpath} -gt 0 ]; then
             camlp4_dir=$(cygpath -w "$camlp4_dir" | sed -e 's;\\;\\\\;g')
             # This makes camlp4_dir a windows path
-        elif [ "${pure_mingw}" = "yes" ]; then
-            # Must double the backslahes
-            camlp4_dir="$(echo "${camlp4_dir}" | sed -e 's;\\;\\\\;g')"
         fi
         camlp4_version=$(camlp4 -v 2>&1)
         if [ "$have_dlls" = "yes" ]; then

--- a/configure
+++ b/configure
@@ -211,7 +211,6 @@ lib_suffix=$(ocamlc -config 2>/dev/null | tr -d '\r' | sed -n -e 's/^ext_lib: //
 
 exec_suffix=
 pure_mingw="no"
-mingw_lib=
 case $(uname) in
   CYGWIN*)
     exec_suffix=.exe
@@ -225,8 +224,6 @@ case $(uname) in
     exec_suffix=.exe
     pure_mingw="yes"
     echo "MinGW build environment found; using .exe as suffix for binaries"
-    mingw_lib=$(get_path gcc)
-    mingw_lib=$(dirname "$mingw_lib")/../lib
     ;;
   *)
     true ;;
@@ -806,10 +803,6 @@ fi
     echo "SYSTEM=${system}"
     echo "NUMTOP=${numtop}"
     echo "SH=${sh}"
-    if [ "$mingw_lib" != "" ]; then
-        echo "OCAMLC_FLAGS=-I \"${mingw_lib}\""
-        echo "OCAMLOPT_FLAGS=-I \"${mingw_lib}\""
-    fi
     echo "OPAQUE=${opaque}"
     echo "OCAMLOPT_G=${native_debugging_info}"
     echo "CHECK_BEFORE_INSTALL=${check_before_install}"

--- a/findlib.conf.in
+++ b/findlib.conf.in
@@ -1,2 +1,0 @@
-destdir="@SITELIB@"
-path="@FINDLIB_PATH@"

--- a/findlib.files
+++ b/findlib.files
@@ -26,7 +26,6 @@
 f configure
 f opam
 f ocamlfind.install
-f findlib.conf.in
 f INSTALL
 f LICENSE
 f Makefile

--- a/findlib.files
+++ b/findlib.files
@@ -54,7 +54,7 @@ f tools/extract_args/extract_args.mll
 f tools/safe_camlp4
 f tools/make-package-macosx
 f tools/patch
-f tools/cmd_from_same_dir
+f tools/cmd_in_different_dirs
 
 d site-lib-src
 d site-lib-src/bigarray

--- a/src/findlib/Makefile
+++ b/src/findlib/Makefile
@@ -89,11 +89,9 @@ findlib_dynload.cmxa: $(DYNLOAD_XOBJECTS)
 	fi
 
 findlib_config.ml: findlib_config.mlp $(TOP)/Makefile.config
-	USE_CYGPATH="$(USE_CYGPATH)"; \
-	export USE_CYGPATH; \
 	cat findlib_config.mlp | \
-	        $(SH) $(TOP)/tools/patch '@CONFIGFILE@' '$(OCAMLFIND_CONF)' | \
-	        $(SH) $(TOP)/tools/patch '@STDLIB@' '$(OCAML_CORE_STDLIB)' | \
+	        $(SH) $(TOP)/tools/patch '@CONFIGFILE@' '$(OCAMLFIND_CONF_NATIVE)' | \
+	        $(SH) $(TOP)/tools/patch '@STDLIB@' '$(OCAML_CORE_STDLIB_NATIVE)' | \
 	        $(SH) $(TOP)/tools/patch '@RELATIVE_PATHS@' '$(RELATIVE_PATHS)' | \
 		sed -e 's;@AUTOLINK@;$(OCAML_AUTOLINK);g' \
 		    -e 's;@SYSTEM@;$(SYSTEM);g' \
@@ -116,10 +114,8 @@ topfind.compat.in: topfind.in
 	fi
 
 topfind: topfind.compat.in
-	USE_CYGPATH="$(USE_CYGPATH)"; \
-	export USE_CYGPATH; \
 	cat topfind.compat.in | \
-	        $(SH) $(TOP)/tools/patch '@SITELIB@' '$(OCAML_SITELIB)' | \
+	        $(SH) $(TOP)/tools/patch '@SITELIB@' '$(OCAML_SITELIB_NATIVE)' | \
 	        $(SH) $(TOP)/tools/patch '@RELATIVE_PATHS@' '$(RELATIVE_PATHS)' \
 	    	    >topfind
 

--- a/src/findlib/findlib.ml
+++ b/src/findlib/findlib.ml
@@ -551,3 +551,20 @@ let record_package_predicates preds =
 let recorded_predicates() =
   !rec_preds
 
+let read_ldconf filename =
+  let lines = ref [] in
+  let f = open_in filename in
+  try
+    while true do
+      let line = input_line f in
+      if line <> "" then
+	lines := line :: !lines
+    done;
+    assert false
+  with
+      End_of_file ->
+	close_in f;
+	List.rev !lines
+    | other ->
+	close_in f;
+	raise other

--- a/src/findlib/findlib.mli
+++ b/src/findlib/findlib.mli
@@ -238,6 +238,9 @@ val list_packages' : ?prefix:string -> unit -> string list
    * @param prefix Limit to the packages that starts with it. Default: unlimited
    *)
 
+val read_ldconf : string -> string list
+  (** Reads and evaluates lines from the supplied ld.conf file. *)
+
 (** Managing dynamically loaded packages *)
 
 (** This is a registry of packages that are available in-core. This is both

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -2138,7 +2138,7 @@ let install_package () =
 	  if !add_files then (
 	    let m1 = Filename.concat !metadir meta_dot_pkg in
 	    let m2 = Filename.concat pkgdir "META" in
-	    if Sys.file_exists m1 then
+            if has_metadir && Sys.file_exists m1 then
 	      m1
 	    else
 	      if Sys.file_exists m2 then
@@ -2153,7 +2153,7 @@ let install_package () =
 
   if not !add_files then (
     (* Check for frequent reasons why installation can go wrong *)
-    if Sys.file_exists (Filename.concat !metadir meta_dot_pkg) then
+    if has_metadir && Sys.file_exists (Filename.concat !metadir meta_dot_pkg) then
       failwith ("Package " ^ !pkgname ^ " is already installed\n - (file " ^ Filename.concat !metadir meta_dot_pkg ^ " already exists)");
 
     if Sys.file_exists (Filename.concat pkgdir "META") then

--- a/src/findlib/frontend.ml
+++ b/src/findlib/frontend.ml
@@ -226,26 +226,6 @@ let use_package prefix pkgnames =
 ;;
 
 
-let read_ldconf filename =
-  let lines = ref [] in
-  let f = open_in filename in
-  try
-    while true do
-      let line = input_line f in
-      if line <> "" then
-	lines := line :: !lines
-    done;
-    assert false
-  with
-      End_of_file ->
-	close_in f;
-	List.rev !lines
-    | other ->
-	close_in f;
-	raise other
-;;
-
-
 let write_ldconf filename lines new_lines =
   let f = open_out filename in
   try

--- a/src/findlib/topfind.in
+++ b/src/findlib/topfind.in
@@ -101,7 +101,7 @@ in
 
 let findlib_directory = match @RELATIVE_PATHS@ with
   | true -> location / "lib" / "findlib"
-  | false -> "@SITELIB@/findlib"
+  | false -> "@SITELIB@" / "findlib"
 in
 
 let () = Topdirs.dir_directory findlib_directory in

--- a/tools/cmd_in_different_dirs
+++ b/tools/cmd_in_different_dirs
@@ -1,7 +1,7 @@
 #! /bin/sh
 
-# Check whether ocamlc and ocamlc.opt are installed in the same
-# directory (or whatever command names are passed as $1).
+# Check whether ocamlc and ocamlc.opt are installed in different
+# directories (or whatever command names are passed as $1).
 
 get_path () {
     IFS=":"
@@ -27,4 +27,4 @@ get_path () {
 p1="$(get_path "$1").opt"
 p2="$(get_path "$1.opt")"
 
-[ "X$p1" = "X$p2" ]
+[ "X$p1" != "X$p2" ]

--- a/tools/patch
+++ b/tools/patch
@@ -1,27 +1,20 @@
 #! /bin/sh
 
-# Usage: patch @VARIABLE@ value [extra-args-for-cygpath]
-# Environment variable USE_CYGPATH is honoured.
+# Usage: patch @VARIABLE@ value
 
 varname="$1"
 varvalue="$2"
 
-if [ "${USE_CYGPATH}" = "1" ]; then
-    #varvalue="$(echo "$varvalue" | sed -e 's;/;\\;g')"
-    varvalue="$(cygpath -w -l $3 "$varvalue")"
-    varvalue="$(echo "$varvalue" | sed -e 's;\\;\\\\\\\\;g;s/;/\\;/g')"
-    # e.g. c:\file is transformed to c:\\\\file
-else
-    case `uname` in
-	MINGW*)
-	    varvalue="$(echo "$varvalue" | sed -e 's;\\;\\\\\\\\;g')"
-	    # Convert the first letter drive to DOS style (naive).
-	    # This is necessary because OCaml uses DOS paths even if
-	    # run under MSYS.
-	    varvalue="$(echo "$varvalue" | sed -e 's;^/\([a-z]\)/;\1:/;g')"
-	    ;;
-    esac
-fi
+case `uname` in
+    MINGW*)
+        # Convert the first letter drive to DOS style (naive).
+        # This is necessary because OCaml uses DOS paths even if
+        # run under MSYS.
+        varvalue="$(echo "$varvalue" | sed -e 's;^/\([a-z]\)/;\1:/;g')"
+        ;;
+esac
+
+varvalue="$(echo "$varvalue" | sed -e 's;\\;\\\\\\\\;g;s/;/\\;/g')"
 
 sed -e 's;'"$varname"';'"$varvalue"';g'
 # e.g. c:\\\\file is parsed by sed as c:\\file which is correct for the


### PR DESCRIPTION
This PR (which is simply a repeat of #112 opened directly) fixes various issues:

- `ocamlfind` does not build with OCaml 5.0+ on Cygwin (a build failure occurs owing to mishandling of the `;` in `path` in the generation of `findlib.conf`). (https://github.com/ocaml/opam/pull/6732)
- When building on mingw-w64/MSVC with OCaml 5.0+ using MSYS2 for the build environment, `findlib.conf` is (silently) misgenerated which causes both `ocamlfind list` and `topfind` to fail. (https://github.com/ocaml/opam-repository/issues/28636)
- `ocamlfind install` contains an incorrect check for `META.pkg` even when `metadir` is not in use (which happened to affect the non-opam installation of `num`).
- Two minor Windows wrinkles: `-s` is not a necessary, nor even always valid, flag to `cygpath` any more and the technically the legacy command for retrieving the Standard Library is broken on old versions of OCaml.

The opening commits are fairly straightforward. The last commit is fiddly, but enacts the following sequence of changes:
1. The generation of `findlib.conf` is shifted from being a build operation to a `configure` operation. That requires the tracking of the native / "Unix" version of various path variables in `configure`, but is fundamentally simpler overall, because we only have to worry about escaping the backslashes which physically go into `findlib.conf` and not also escaping characters which may interfere with an escaping `sed` expression!
2. That allows `tools/patch` to be able to assume that it has received a native path (modulo the highly legacy stuff for the MinGW environment, but this probably ought to all be removed).
3. That then allows various variables which are no longer required the the build to be removed.

Fixes Cygwin failure in https://github.com/ocaml/opam/pull/6732
Closes https://github.com/ocaml/opam-repository/issues/28636